### PR TITLE
[노철] - 수정, 쓰기를 위한 계획 컴포넌트

### DIFF
--- a/src/components/InputTag/InputTag.tsx
+++ b/src/components/InputTag/InputTag.tsx
@@ -33,6 +33,7 @@ export default function InputTag({
           placeholder="태그를 입력해주세요"
           value={inputValue}
           onChange={handleInputChange}
+          maxLength={10}
         />
       </form>
     </Tag>

--- a/src/components/InputTag/index.scss
+++ b/src/components/InputTag/index.scss
@@ -2,12 +2,16 @@
   position: relative;
   &:focus-within {
     &::after {
-      content: '엔터시 입력, 태그 클릭시 삭제 , 최대 5개 ';
+      content: '엔터시 태그가 추가되며, 최대 5개, 태그 클릭시 삭제 ';
       position: absolute;
-      color: black;
+      color: var(--origin-white-200);
+      background-color: var(--origin-gray-200);
       left: 0;
-      bottom: -20px;
+      margin-top: 0.5rem;
       display: block;
+      border-radius: var(--border-radius);
+      padding: 0 0.5rem 0 0.5rem;
+      z-index: 1;
     }
   }
   &__tag {

--- a/src/components/WritablePlan/WritablePlan.tsx
+++ b/src/components/WritablePlan/WritablePlan.tsx
@@ -1,0 +1,143 @@
+import { Color } from '@/types';
+import { useState } from 'react';
+import {
+  AjajaButton,
+  Icon,
+  IconSwitchButton,
+  InputTag,
+  PlanInput,
+  Tag,
+} from '..';
+import './index.scss';
+
+interface WritablePlanProps {
+  isEditPage: boolean; // 에디터 페이지인지 여부
+  isPublic: boolean; // 현재 계획 공개여부
+  onToggleIsPublic: () => void; // 계획 공개여부 변경
+  title: string;
+  description: string;
+  onChangeTitle: (text: string) => void;
+  onChangeDescription: (text: string) => void;
+  tags: string[];
+  changeTags: (tags: string[]) => void; //태그 리스트에 추가,삭제를 위한 삭제를 전체를 넘겨주는 방식
+  ajajas?: number;
+  isAjajaOn?: boolean;
+  canAjaja?: boolean;
+  onToggleCanAjaja?: () => void; // api 전송이 아닌 상태변경용
+}
+export default function WritablePlan({
+  isEditPage,
+  isPublic,
+  onToggleIsPublic,
+  title,
+  description,
+  onChangeTitle,
+  onChangeDescription,
+  tags,
+  changeTags,
+  ajajas = 0,
+  isAjajaOn = false,
+  canAjaja = false,
+  onToggleCanAjaja,
+}: WritablePlanProps) {
+  const [inputTagValue, setInputValue] = useState<string>('');
+  const colors: Color[] = [
+    'primary',
+    'orange-300',
+    'green-300',
+    'blue-300',
+    'purple-300',
+  ];
+  const handlePopUpGuide = () => {
+    console.log('가이드라인');
+  };
+  const handleRemoveTag = (removedTag: string) => {
+    const filterd = tags.filter((tag) => tag !== removedTag);
+    changeTags(filterd);
+  };
+  const handleAddTag = () => {
+    const trimed = inputTagValue.trim();
+    if (tags.includes(trimed) || tags.length >= 5) {
+      setInputValue('');
+      return;
+    }
+    const newTagList = [...tags, trimed];
+    changeTags(newTagList);
+    setInputValue('');
+  };
+  return (
+    <div className="plan__container">
+      <div className="plan__header">
+        <h1 className="font-size-3xl">
+          {isEditPage ? '계획' : '신년 계획을 작성해 보세요!'}
+        </h1>
+        <IconSwitchButton
+          isActive={isPublic}
+          onClick={onToggleIsPublic}
+          onIconName="PLAN_OPEN"
+          offIconName="PLAN_CLOSE"
+        />
+        <span className="plan__header--after color-origin-gray-200">
+          계획 공개
+        </span>
+        {isEditPage && (
+          <button
+            className="plan__header--after--guide-button"
+            onClick={handlePopUpGuide}>
+            <Icon name="HELP" />
+          </button>
+        )}
+      </div>
+      <div className="plan__content">
+        <PlanInput
+          editable={true}
+          kind="title"
+          placeholder="어떤 계획을 가지고 계신가요?"
+          onChangeInput={onChangeTitle}
+          maxLength={40}
+          textInput={title}
+        />
+        <PlanInput
+          editable={true}
+          kind="content"
+          placeholder="계획에 대해서 자세히 설명해주세요!"
+          onChangeInput={onChangeDescription}
+          maxLength={250}
+          textInput={description}
+        />
+        <div>
+          <InputTag
+            inputValue={inputTagValue}
+            onChange={setInputValue}
+            onSubmit={handleAddTag}
+          />
+          {tags.map((tag, index) => (
+            <Tag
+              key={index}
+              color={colors[index % 5]}
+              onClick={() => {
+                handleRemoveTag(tag);
+              }}>
+              {tag}
+            </Tag>
+          ))}
+        </div>
+      </div>
+      {isEditPage && (
+        <div className="plan__bottom">
+          <AjajaButton isFilled={isAjajaOn} ajajaCount={ajajas} />
+          <IconSwitchButton
+            onIconName="NOTIFICATION_ON"
+            offIconName="NOTIFICATION_OFF"
+            isActive={canAjaja}
+            onClick={onToggleCanAjaja ? onToggleCanAjaja : () => {}}
+          />
+          <div className="plan__bottom--after color-origin-gray-200 font-size-xs">
+            <span>월요일 18:00 마다</span>
+            <span>응원 메시지 알람 활성화</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/WritablePlan/index.scss
+++ b/src/components/WritablePlan/index.scss
@@ -1,0 +1,42 @@
+.plan {
+  &__container {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  &__header {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    &--after--guide-button {
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      border: none;
+      background-color: transparent;
+      &:hover {
+        cursor: pointer;
+      }
+    }
+  }
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+    &--tags {
+      margin-top: -1rem;
+    }
+  }
+
+  &__bottom {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    &--after {
+      display: flex;
+      flex-direction: column;
+      text-align: center;
+    }
+  }
+}


### PR DESCRIPTION
## 📌 이슈 번호

close #70

## 🚀 구현 내용
<img width="498" alt="image" src="https://github.com/New-Barams/this-year-ajaja-fe/assets/61609327/4c258e42-73cd-4f2b-9a8c-65ba99922821">

받고있는 props
<img width="507" alt="스크린샷 2023-11-18 005719" src="https://github.com/New-Barams/this-year-ajaja-fe/assets/61609327/daba3c29-74c0-4c7e-a3cd-f4852745a68a">

실제 사용 예시
<img width="329" alt="스크린샷 2023-11-18 005633" src="https://github.com/New-Barams/this-year-ajaja-fe/assets/61609327/db8966e5-daf5-4596-94c4-677bcdd8a836">



## 📘 참고 사항
아직은 단순 로직만 넣었습니다. 
<!--## ❓ 궁금한 내용-->
