### PR TITLE
[혜수] 다른 계획 둘러보기 구현

### DIFF
--- a/src/apis/client/getAllPlans.ts
+++ b/src/apis/client/getAllPlans.ts
@@ -1,12 +1,12 @@
+import { GetAllPlansResponse } from '@/types/apis/plan/GetAllPlans';
 import { axiosInstanceClient } from '../axiosInstanceClient';
 
 export const getAllPlans = async () => {
-  try {
-    const { data } = await axiosInstanceClient.get('/plans', {
+  const { data } = await axiosInstanceClient.get<GetAllPlansResponse>(
+    '/plans',
+    {
       authorization: false,
-    });
-    return data;
-  } catch (error) {
-    console.log('Error:', error);
-  }
+    },
+  );
+  return data;
 };

--- a/src/app/(header)/_components/index.scss
+++ b/src/app/(header)/_components/index.scss
@@ -1,12 +1,14 @@
 .header-layout {
   max-width: 100vw;
   max-height: 100vh;
+  overflow-y: hidden;
   &__wrapper {
     height: 100%;
-    padding: 20px 80px 20px 80px;
+    padding: 1rem 5rem 1rem 5rem;
   }
   &__content {
-    margin-top: 20px;
-    min-height: 85vh;
+    margin-top: 1rem;
+    height: 90vh;
+    overflow: scroll;
   }
 }

--- a/src/app/(header)/explore/_components/Card/Card.tsx
+++ b/src/app/(header)/explore/_components/Card/Card.tsx
@@ -1,7 +1,21 @@
+import { AjajaButton, Tag } from '@/components';
+import { Color } from '@/types';
+import { CardPlans } from '@/types/apis/plan/GetAllPlans';
 import classNames from 'classnames';
 import './index.scss';
 
-export default function Card() {
+const color: Color[] = [
+  'primary',
+  'orange-300',
+  'green-300',
+  'blue-300',
+  'purple-300',
+];
+
+type CardProps = {
+  plan: CardPlans;
+};
+export default function Card({ plan }: CardProps) {
   return (
     <div className={classNames('card__wrapper')}>
       <div
@@ -16,7 +30,44 @@ export default function Card() {
           'border-round',
           'border-origin-orange-300',
           'background-origin-white-300',
-        )}></div>
+        )}>
+        <div className={classNames('card__contents-wrapper')}>
+          <p
+            className={classNames(
+              'card__contents--title',
+              'font-size-lg',
+              'color-origin-gray-300',
+            )}>
+            {plan.title}
+          </p>
+          <p
+            className={classNames(
+              'card__contents--nickname',
+              'font-size-sm',
+              'color-origin-gray-200',
+            )}>
+            {plan.nickname}님의 계획 • {plan.createdAt.slice(0, 4)}년 작성
+          </p>
+          <div className={classNames('card__contents--tags', 'font-size-xs')}>
+            {plan.tags.map((tag, index) => {
+              return (
+                <Tag
+                  key={index}
+                  color={color[index]}
+                  style={{ padding: '0.2rem 0.5rem' }}>
+                  {tag}
+                </Tag>
+              );
+            })}
+          </div>
+          <AjajaButton
+            ajajaCount={plan.ajajas}
+            isFilled={!!plan.ajajas}
+            classNameList={['card__contents--ajaja']}
+            disabled
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/(header)/explore/_components/Card/Card.tsx
+++ b/src/app/(header)/explore/_components/Card/Card.tsx
@@ -1,0 +1,22 @@
+import classNames from 'classnames';
+import './index.scss';
+
+export default function Card() {
+  return (
+    <div className={classNames('card__wrapper')}>
+      <div
+        className={classNames(
+          'card__background',
+          'border-round',
+          'background-origin-orange-300',
+        )}></div>
+      <div
+        className={classNames(
+          'card__contents',
+          'border-round',
+          'border-origin-orange-300',
+          'background-origin-white-300',
+        )}></div>
+    </div>
+  );
+}

--- a/src/app/(header)/explore/_components/Card/index.scss
+++ b/src/app/(header)/explore/_components/Card/index.scss
@@ -1,0 +1,25 @@
+@use 'sass:math';
+
+$card_width: 20rem;
+$card_height: 12rem;
+$card_gap: 0.5rem;
+
+.card {
+  &__wrapper {
+    width: $card_width;
+    height: $card_height;
+    position: relative;
+  }
+  &__background {
+    width: calc($card_width - $card_gap);
+    height: calc($card_height - $card_gap);
+    margin-left: $card_gap;
+  }
+  &__contents {
+    width: calc($card_width - $card_gap);
+    height: calc($card_height - $card_gap);
+    border-width: 5px;
+    position: absolute;
+    top: $card_gap;
+  }
+}

--- a/src/app/(header)/explore/_components/Card/index.scss
+++ b/src/app/(header)/explore/_components/Card/index.scss
@@ -1,6 +1,6 @@
 @use 'sass:math';
 
-$card_width: 20rem;
+$card_width: 19rem;
 $card_height: 12rem;
 $card_gap: 0.5rem;
 

--- a/src/app/(header)/explore/_components/Card/index.scss
+++ b/src/app/(header)/explore/_components/Card/index.scss
@@ -4,6 +4,14 @@ $card_width: 20rem;
 $card_height: 12rem;
 $card_gap: 0.5rem;
 
+@mixin ellipsis($line) {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: $line;
+  -webkit-box-orient: vertical;
+}
+
 .card {
   &__wrapper {
     width: $card_width;
@@ -21,5 +29,31 @@ $card_gap: 0.5rem;
     border-width: 5px;
     position: absolute;
     top: $card_gap;
+    display: flex;
+    justify-content: center;
+    &-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: start;
+    }
+    &--title {
+      width: calc($card_width - 3rem);
+      @include ellipsis(2);
+      margin-top: 2rem;
+    }
+    &--nickname {
+      @include ellipsis(1);
+      position: absolute;
+      margin-top: 5rem;
+    }
+    &--tags {
+      @include ellipsis(1);
+      position: absolute;
+      margin: 6.5rem 0 0 -0.4rem;
+    }
+    &--ajaja {
+      position: absolute;
+      margin: 8.25rem 0 0 calc($card_width - 6.5rem);
+    }
   }
 }

--- a/src/app/(header)/explore/_components/ExplorePlans.tsx
+++ b/src/app/(header)/explore/_components/ExplorePlans.tsx
@@ -1,0 +1,10 @@
+// import { useState } from 'react';
+import Tab from './Tab/Tab';
+
+export default function ExplorePlans() {
+  return (
+    <div>
+      <Tab />
+    </div>
+  );
+}

--- a/src/app/(header)/explore/_components/ExplorePlans.tsx
+++ b/src/app/(header)/explore/_components/ExplorePlans.tsx
@@ -1,10 +1,11 @@
-// import { useState } from 'react';
+import Plans from './Plans/Plans';
 import Tab from './Tab/Tab';
 
 export default function ExplorePlans() {
   return (
     <div>
       <Tab />
+      <Plans />
     </div>
   );
 }

--- a/src/app/(header)/explore/_components/ExplorePlans.tsx
+++ b/src/app/(header)/explore/_components/ExplorePlans.tsx
@@ -1,9 +1,11 @@
+import classNames from 'classnames';
 import Plans from './Plans/Plans';
 import Tab from './Tab/Tab';
+import './index.scss';
 
 export default function ExplorePlans() {
   return (
-    <div>
+    <div className={classNames('explore-plans__wrapper')}>
       <Tab />
       <Plans />
     </div>

--- a/src/app/(header)/explore/_components/Plans/Plans.tsx
+++ b/src/app/(header)/explore/_components/Plans/Plans.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import classNames from 'classnames';
 import Link from 'next/link';
 // import { useAllPlansQuery } from '@/hooks/apis/plans/useAllPlansQuery';
 import Card from '../Card/Card';
+import './index.scss';
 
 export default function Plans() {
   // const { allPlans } = useAllPlansQuery();
@@ -60,10 +62,160 @@ export default function Plans() {
         tags: ['태그', '태그', '태태', '태태', '태태'],
         createdAt: '2023-??',
       },
+      {
+        id: 0,
+        userId: 1,
+        nickname: '춤추는 고래',
+        title:
+          '올해도 아좌좌 아좌좌 아좌좌 아좌좌 아좌좌 아좌좌 아좌좌 아좌좌 ',
+        ajajas: 255,
+        tags: ['태그', '태그태그', '태태태태태태그'],
+        createdAt: '2023-??',
+      },
+      {
+        id: 1,
+        userId: 2,
+        nickname: '윈드밀하는 미어캣zooooooooooo',
+        title:
+          '올해도 아좌좌 아좌좌 아좌좌 김수한무거북이와두루미암튼모르겠는데긴이름름이름이다',
+        ajajas: 0,
+        tags: [
+          '태그',
+          '태그태그',
+          '태태태태태태그',
+          '태태태태태태그',
+          '태태태태그태태태태그',
+        ],
+        createdAt: '2023-??',
+      },
+      {
+        id: 2,
+        userId: 2,
+        nickname: '윈드밀하는 미어캣',
+        title: '올해도 아좌좌 아좌좌',
+        ajajas: 1000,
+        tags: [
+          '태그',
+          '태그태그',
+          '태태태태태태그',
+          '태태태태태태그',
+          '태태태태그태태태태그',
+        ],
+        createdAt: '2023-??',
+      },
+      {
+        id: 3,
+        userId: 2,
+        nickname: '윈드밀하는 미어캣',
+        title: '올해도 아좌좌 아좌좌',
+        ajajas: 2231,
+        tags: ['태그', '태그', '태태', '태태', '태태'],
+        createdAt: '2023-??',
+      },
+      {
+        id: 0,
+        userId: 1,
+        nickname: '춤추는 고래',
+        title:
+          '올해도 아좌좌 아좌좌 아좌좌 아좌좌 아좌좌 아좌좌 아좌좌 아좌좌 ',
+        ajajas: 255,
+        tags: ['태그', '태그태그', '태태태태태태그'],
+        createdAt: '2023-??',
+      },
+      {
+        id: 1,
+        userId: 2,
+        nickname: '윈드밀하는 미어캣zooooooooooo',
+        title:
+          '올해도 아좌좌 아좌좌 아좌좌 김수한무거북이와두루미암튼모르겠는데긴이름름이름이다',
+        ajajas: 0,
+        tags: [
+          '태그',
+          '태그태그',
+          '태태태태태태그',
+          '태태태태태태그',
+          '태태태태그태태태태그',
+        ],
+        createdAt: '2023-??',
+      },
+      {
+        id: 2,
+        userId: 2,
+        nickname: '윈드밀하는 미어캣',
+        title: '올해도 아좌좌 아좌좌',
+        ajajas: 1000,
+        tags: [
+          '태그',
+          '태그태그',
+          '태태태태태태그',
+          '태태태태태태그',
+          '태태태태그태태태태그',
+        ],
+        createdAt: '2023-??',
+      },
+      {
+        id: 3,
+        userId: 2,
+        nickname: '윈드밀하는 미어캣',
+        title: '올해도 아좌좌 아좌좌',
+        ajajas: 2231,
+        tags: ['태그', '태그', '태태', '태태', '태태'],
+        createdAt: '2023-??',
+      },
+      {
+        id: 0,
+        userId: 1,
+        nickname: '춤추는 고래',
+        title:
+          '올해도 아좌좌 아좌좌 아좌좌 아좌좌 아좌좌 아좌좌 아좌좌 아좌좌 ',
+        ajajas: 255,
+        tags: ['태그', '태그태그', '태태태태태태그'],
+        createdAt: '2023-??',
+      },
+      {
+        id: 1,
+        userId: 2,
+        nickname: '윈드밀하는 미어캣zooooooooooo',
+        title:
+          '올해도 아좌좌 아좌좌 아좌좌 김수한무거북이와두루미암튼모르겠는데긴이름름이름이다',
+        ajajas: 0,
+        tags: [
+          '태그',
+          '태그태그',
+          '태태태태태태그',
+          '태태태태태태그',
+          '태태태태그태태태태그',
+        ],
+        createdAt: '2023-??',
+      },
+      {
+        id: 2,
+        userId: 2,
+        nickname: '윈드밀하는 미어캣',
+        title: '올해도 아좌좌 아좌좌',
+        ajajas: 1000,
+        tags: [
+          '태그',
+          '태그태그',
+          '태태태태태태그',
+          '태태태태태태그',
+          '태태태태그태태태태그',
+        ],
+        createdAt: '2023-??',
+      },
+      {
+        id: 3,
+        userId: 2,
+        nickname: '윈드밀하는 미어캣',
+        title: '올해도 아좌좌 아좌좌',
+        ajajas: 2231,
+        tags: ['태그', '태그', '태태', '태태', '태태'],
+        createdAt: '2023-??',
+      },
     ],
   };
   return (
-    <>
+    <div className={classNames('plans__wrapper')}>
       {allPlans.data.map((plan, index) => {
         return (
           <Link key={index} href={`/plans/${plan.id}`}>
@@ -71,6 +223,6 @@ export default function Plans() {
           </Link>
         );
       })}
-    </>
+    </div>
   );
 }

--- a/src/app/(header)/explore/_components/Plans/Plans.tsx
+++ b/src/app/(header)/explore/_components/Plans/Plans.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+// import { useAllPlansQuery } from '@/hooks/apis/plans/useAllPlansQuery';
+import Card from '../Card/Card';
+
+export default function Plans() {
+  // const { allPlans } = useAllPlansQuery();
+  // console.log(allPlans.data);
+  const allPlans = {
+    success: true,
+    data: [
+      {
+        id: 0,
+        userId: 1,
+        nickname: '춤추는 고래',
+        title:
+          '올해도 아좌좌 아좌좌 아좌좌 아좌좌 아좌좌 아좌좌 아좌좌 아좌좌 ',
+        ajajas: 255,
+        tags: ['태그', '태그태그', '태태태태태태그'],
+        createdAt: '2023-??',
+      },
+      {
+        id: 1,
+        userId: 2,
+        nickname: '윈드밀하는 미어캣zooooooooooo',
+        title:
+          '올해도 아좌좌 아좌좌 아좌좌 김수한무거북이와두루미암튼모르겠는데긴이름름이름이다',
+        ajajas: 0,
+        tags: [
+          '태그',
+          '태그태그',
+          '태태태태태태그',
+          '태태태태태태그',
+          '태태태태그태태태태그',
+        ],
+        createdAt: '2023-??',
+      },
+      {
+        id: 1,
+        userId: 2,
+        nickname: '윈드밀하는 미어캣',
+        title: '올해도 아좌좌 아좌좌',
+        ajajas: 1000,
+        tags: [
+          '태그',
+          '태그태그',
+          '태태태태태태그',
+          '태태태태태태그',
+          '태태태태그태태태태그',
+        ],
+        createdAt: '2023-??',
+      },
+      {
+        id: 1,
+        userId: 2,
+        nickname: '윈드밀하는 미어캣',
+        title: '올해도 아좌좌 아좌좌',
+        ajajas: 2231,
+        tags: ['태그', '태그', '태태', '태태', '태태'],
+        createdAt: '2023-??',
+      },
+    ],
+  };
+  return (
+    <>
+      {allPlans.data.map((plan, index) => {
+        return <Card key={index} plan={plan} />;
+      })}
+    </>
+  );
+}

--- a/src/app/(header)/explore/_components/Plans/Plans.tsx
+++ b/src/app/(header)/explore/_components/Plans/Plans.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 // import { useAllPlansQuery } from '@/hooks/apis/plans/useAllPlansQuery';
 import Card from '../Card/Card';
 
@@ -36,7 +37,7 @@ export default function Plans() {
         createdAt: '2023-??',
       },
       {
-        id: 1,
+        id: 2,
         userId: 2,
         nickname: '윈드밀하는 미어캣',
         title: '올해도 아좌좌 아좌좌',
@@ -51,7 +52,7 @@ export default function Plans() {
         createdAt: '2023-??',
       },
       {
-        id: 1,
+        id: 3,
         userId: 2,
         nickname: '윈드밀하는 미어캣',
         title: '올해도 아좌좌 아좌좌',
@@ -64,7 +65,11 @@ export default function Plans() {
   return (
     <>
       {allPlans.data.map((plan, index) => {
-        return <Card key={index} plan={plan} />;
+        return (
+          <Link key={index} href={`/plans/${plan.id}`}>
+            <Card key={index} plan={plan} />
+          </Link>
+        );
       })}
     </>
   );

--- a/src/app/(header)/explore/_components/Plans/index.scss
+++ b/src/app/(header)/explore/_components/Plans/index.scss
@@ -1,0 +1,13 @@
+.plans {
+  &__wrapper {
+    display: grid;
+    align-items: center;
+    justify-content: center;
+    align-items: center;
+    justify-items: center;
+    margin-top: 1rem;
+    grid-template-rows: repeat(auto-fill, 12rem);
+    grid-template-columns: repeat(auto-fill, 21rem);
+    grid-row-gap: 3rem;
+  }
+}

--- a/src/app/(header)/explore/_components/Plans/index.scss
+++ b/src/app/(header)/explore/_components/Plans/index.scss
@@ -5,9 +5,10 @@
     justify-content: center;
     align-items: center;
     justify-items: center;
-    margin-top: 1rem;
-    grid-template-rows: repeat(auto-fill, 12rem);
-    grid-template-columns: repeat(auto-fill, 21rem);
+    margin: 1rem -1rem;
+    grid-template-rows: repeat(auto-fill, minmax(12rem, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
     grid-row-gap: 3rem;
+    grid-auto-flow: dense;
   }
 }

--- a/src/app/(header)/explore/_components/Tab/Tab.tsx
+++ b/src/app/(header)/explore/_components/Tab/Tab.tsx
@@ -5,39 +5,45 @@ import { useState } from 'react';
 import './index.scss';
 
 export default function Tab() {
-  const [currentTab, setCurrentTab] = useState(0);
+  const [currentYearTab, setCurrentYearTab] = useState(0);
+  const [currentSortTab, setCurrentSortTab] = useState(0);
 
-  const menu = [
+  const yearMenu = [
     { name: '새해' },
     {
       name: '지난해',
     },
   ];
+  const sortMenu = [{ name: '최신순' }, { name: '인기순' }];
 
-  const selectMenuHandler = (index: number) => {
-    setCurrentTab(index);
+  const selectYearMenuHandler = (index: number) => {
+    setCurrentYearTab(index);
+    console.log(index);
+  };
+  const selectSortMenuHandler = (index: number) => {
+    setCurrentSortTab(index);
     console.log(index);
   };
   return (
     <div className={classNames('tab__wrapper')}>
       <div className={classNames('tab__wrapper-year')}>
-        <div className={classNames('tab__menu')}>
-          {menu.map((el, index) => {
+        <div className={classNames('tab__year-menu')}>
+          {yearMenu.map((el, index) => {
             return (
               <li
                 key={index}
                 className={classNames(
-                  'tab__menu--align',
-                  index === currentTab
-                    ? 'tab__menu--focused'
-                    : 'tab__menu--normal',
+                  'tab__year-menu--align',
+                  index === currentYearTab
+                    ? 'tab__year-menu--focused'
+                    : 'tab__year-menu--normal',
                 )}
-                onClick={() => selectMenuHandler(index)}>
+                onClick={() => selectYearMenuHandler(index)}>
                 {el.name}
                 <div
                   className={classNames(
-                    'tab__menu--underline',
-                    index === currentTab
+                    'tab__year-menu--underline',
+                    index === currentYearTab
                       ? 'background-origin-primary'
                       : 'background-origin-orange-200',
                   )}
@@ -50,6 +56,28 @@ export default function Tab() {
       <div
         className={classNames('tab__line', 'background-origin-orange-200')}
       />
+      <div className={classNames('tab__wrapper-sort', 'font-size-sm')}>
+        {sortMenu.map((el, index) => {
+          return (
+            <>
+              {!!index && (
+                <p className={classNames('color-origin-gray-200')}>|</p>
+              )}
+              <li
+                key={index}
+                className={classNames(
+                  'tab__sort-menu--align',
+                  index === currentSortTab
+                    ? 'tab__sort-menu--focused'
+                    : 'tab__sort-menu--normal',
+                )}
+                onClick={() => selectSortMenuHandler(index)}>
+                {el.name}
+              </li>
+            </>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/app/(header)/explore/_components/Tab/Tab.tsx
+++ b/src/app/(header)/explore/_components/Tab/Tab.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import classNames from 'classnames';
+import { useState } from 'react';
+import './index.scss';
+
+export default function Tab() {
+  const [currentTab, setCurrentTab] = useState(0);
+
+  const menu = [
+    { name: '새해' },
+    {
+      name: '지난해',
+    },
+  ];
+
+  const selectMenuHandler = (index: number) => {
+    setCurrentTab(index);
+    console.log(index);
+  };
+  return (
+    <div className={classNames('tab__wrapper')}>
+      <div className={classNames('tab__wrapper-year')}>
+        <div className={classNames('tab__menu')}>
+          {menu.map((el, index) => {
+            return (
+              <li
+                key={index}
+                className={classNames(
+                  'tab__menu--align',
+                  index === currentTab
+                    ? 'tab__menu--focused'
+                    : 'tab__menu--normal',
+                )}
+                onClick={() => selectMenuHandler(index)}>
+                {el.name}
+                <div
+                  className={classNames(
+                    'tab__menu--underline',
+                    index === currentTab
+                      ? 'background-origin-primary'
+                      : 'background-origin-orange-200',
+                  )}
+                />
+              </li>
+            );
+          })}
+        </div>
+      </div>
+      <div
+        className={classNames('tab__line', 'background-origin-orange-200')}
+      />
+    </div>
+  );
+}

--- a/src/app/(header)/explore/_components/Tab/Tab.tsx
+++ b/src/app/(header)/explore/_components/Tab/Tab.tsx
@@ -18,11 +18,9 @@ export default function Tab() {
 
   const selectYearMenuHandler = (index: number) => {
     setCurrentYearTab(index);
-    console.log(index);
   };
   const selectSortMenuHandler = (index: number) => {
     setCurrentSortTab(index);
-    console.log(index);
   };
   return (
     <div className={classNames('tab__wrapper')}>

--- a/src/app/(header)/explore/_components/Tab/Tab.tsx
+++ b/src/app/(header)/explore/_components/Tab/Tab.tsx
@@ -2,6 +2,7 @@
 
 import classNames from 'classnames';
 import { useState } from 'react';
+import React from 'react';
 import './index.scss';
 
 export default function Tab() {
@@ -57,7 +58,7 @@ export default function Tab() {
       <div className={classNames('tab__wrapper-sort', 'font-size-sm')}>
         {sortMenu.map((el, index) => {
           return (
-            <>
+            <React.Fragment key={index}>
               {!!index && (
                 <p className={classNames('color-origin-gray-200')}>|</p>
               )}
@@ -72,7 +73,7 @@ export default function Tab() {
                 onClick={() => selectSortMenuHandler(index)}>
                 {el.name}
               </li>
-            </>
+            </React.Fragment>
           );
         })}
       </div>

--- a/src/app/(header)/explore/_components/Tab/index.scss
+++ b/src/app/(header)/explore/_components/Tab/index.scss
@@ -1,0 +1,45 @@
+$tab_width: 90%;
+$tab_underline_height: 0.125rem;
+.tab {
+  &__wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    position: relative;
+    &-year {
+      width: $tab_width;
+    }
+  }
+  &__menu {
+    display: flex;
+    list-style: none;
+    gap: 2rem;
+    margin: 2rem 0 1rem 0.875rem;
+    &--align {
+      display: flex;
+      justify-content: center;
+      position: relative;
+    }
+    &--focused {
+      color: var(--origin-primary);
+      &:hover {
+        cursor: pointer;
+      }
+    }
+    &--normal {
+      &:hover {
+        cursor: pointer;
+      }
+    }
+    &--underline {
+      position: absolute;
+      top: 2rem;
+      height: $tab_underline_height;
+      width: 200%;
+    }
+  }
+  &__line {
+    width: $tab_width;
+    height: $tab_underline_height;
+  }
+}

--- a/src/app/(header)/explore/_components/Tab/index.scss
+++ b/src/app/(header)/explore/_components/Tab/index.scss
@@ -9,8 +9,15 @@ $tab_underline_height: 0.125rem;
     &-year {
       width: $tab_width;
     }
+    &-sort {
+      display: flex;
+      width: $tab_width;
+      justify-content: flex-end;
+      gap: 0.5rem;
+      margin: 1rem 0 1rem 0;
+    }
   }
-  &__menu {
+  &__year-menu {
     display: flex;
     list-style: none;
     gap: 2rem;
@@ -27,6 +34,7 @@ $tab_underline_height: 0.125rem;
       }
     }
     &--normal {
+      color: var(--origin-gray-200);
       &:hover {
         cursor: pointer;
       }
@@ -41,5 +49,24 @@ $tab_underline_height: 0.125rem;
   &__line {
     width: $tab_width;
     height: $tab_underline_height;
+  }
+  &__sort-menu {
+    &--align {
+      display: flex;
+      justify-content: center;
+      position: relative;
+    }
+    &--focused {
+      color: var(--origin-orange-300);
+      &:hover {
+        cursor: pointer;
+      }
+    }
+    &--normal {
+      color: var(--origin-gray-200);
+      &:hover {
+        cursor: pointer;
+      }
+    }
   }
 }

--- a/src/app/(header)/explore/_components/Tab/index.scss
+++ b/src/app/(header)/explore/_components/Tab/index.scss
@@ -1,4 +1,4 @@
-$tab_width: 90%;
+$tab_width: 100%;
 $tab_underline_height: 0.125rem;
 .tab {
   &__wrapper {

--- a/src/app/(header)/explore/_components/index.scss
+++ b/src/app/(header)/explore/_components/index.scss
@@ -1,0 +1,10 @@
+.explore {
+  &-plans {
+    &__wrapper {
+      width: 90%;
+      display: flex;
+      flex-direction: column;
+      margin: auto;
+    }
+  }
+}

--- a/src/app/(header)/explore/page.tsx
+++ b/src/app/(header)/explore/page.tsx
@@ -1,11 +1,5 @@
-import classNames from 'classnames';
 import ExplorePlans from './_components/ExplorePlans';
-import './_components/index.scss';
 
 export default function ExplorePage() {
-  return (
-    <div className={classNames('explore-plans')}>
-      <ExplorePlans />
-    </div>
-  );
+  return <ExplorePlans />;
 }

--- a/src/app/(header)/explore/page.tsx
+++ b/src/app/(header)/explore/page.tsx
@@ -1,3 +1,11 @@
+import classNames from 'classnames';
+import ExplorePlans from './_components/ExplorePlans';
+import './_components/index.scss';
+
 export default function ExplorePage() {
-  return <h2>explorePage</h2>;
+  return (
+    <div className={classNames('explore-plans')}>
+      <ExplorePlans />
+    </div>
+  );
 }

--- a/src/components/AjajaButton/AjajaButton.tsx
+++ b/src/components/AjajaButton/AjajaButton.tsx
@@ -11,11 +11,13 @@ interface AjajaButtonProps
   extends PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>> {
   isFilled: boolean;
   ajajaCount: number;
+  classNameList?: string[];
 }
 
 export default function AjajaButton({
   isFilled,
   ajajaCount,
+  classNameList = [],
   ...props
 }: AjajaButtonProps) {
   const [count, setCount] = useState(ajajaCount);
@@ -42,9 +44,9 @@ export default function AjajaButton({
     <button
       className={classNames(
         `ajaja-button`,
-        `background-origin-white-200`,
         `color-origin-gray-300`,
-        `font-size-base`,
+        `font-size-sm`,
+        classNameList,
       )}
       onClick={handleAjaja}
       {...props}>
@@ -61,7 +63,7 @@ export default function AjajaButton({
           아좌좌
         </p>
       </div>
-      {count}
+      {count >= 1000 ? Math.floor(count / 1000) + 'k' : count}
     </button>
   );
 }

--- a/src/components/AjajaButton/index.scss
+++ b/src/components/AjajaButton/index.scss
@@ -2,8 +2,8 @@
   &-button {
     display: flex;
     align-items: center;
+    background-color: transparent;
     gap: 5px;
-    font-weight: bold;
     border: none;
     &:hover {
       cursor: pointer;

--- a/src/hooks/apis/plans/useAllPlansQuery.ts
+++ b/src/hooks/apis/plans/useAllPlansQuery.ts
@@ -1,0 +1,13 @@
+'use client';
+
+import { getAllPlans } from '@/apis/client/getAllPlans';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+export const useAllPlansQuery = () => {
+  const { data } = useSuspenseQuery({
+    queryKey: ['all_plans'],
+    queryFn: getAllPlans,
+    staleTime: 10000,
+  });
+  return { allPlans: data! };
+};

--- a/src/provider/TanstackQueryProvider.tsx
+++ b/src/provider/TanstackQueryProvider.tsx
@@ -4,22 +4,19 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import React from 'react';
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      suspense: true,
+    },
+  },
+});
+
 export default function TanstackQueryProvider({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const [queryClient] = React.useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            suspense: true,
-          },
-        },
-      }),
-  );
-
   return (
     <QueryClientProvider client={queryClient}>
       {children}

--- a/src/types/apis/plan/GetAllPlans.ts
+++ b/src/types/apis/plan/GetAllPlans.ts
@@ -1,0 +1,14 @@
+export interface GetAllPlansResponse {
+  success: boolean;
+  data: CardPlans[];
+}
+
+export interface CardPlans {
+  id: number;
+  userId: number;
+  nickname: string;
+  title: string;
+  ajajas: number;
+  tags: string[];
+  createdAt: string;
+}


### PR DESCRIPTION
## 📌 이슈 번호

close #53 

## 🚀 구현 내용
- 탭, 정렬 추가
- 카드 컴포넌트 생성
- ajaja 버튼 수정 (배경색 제거 및 글자 스타일 수정 & classNameList 추가)
- 카드 나름 반응형 구현...?
- useAllPlansQuery 추가 -> 민우님 PR 참고해서 키값 수정필요할 것 같습니다.
- 스크롤 border 내부로 변경했습니다. -> 이제 스크롤 디자인 안어울리는거같아요.. 
![ezgif com-video-to-gif](https://github.com/New-Barams/this-year-ajaja-fe/assets/67812466/58c0cc89-9fc2-4eb0-b910-5a59a0d0fa0a)

<!--## 📘 참고 사항-->

## ❓ 궁금한 내용
카드에서 아좌좌는 아직 못누를 것 같습니다.
만약 누르게 하고싶다면 자신이 눌렀는지 안눌렀는지 로그인 여부 확인에 따라 불러오는 API가 달라져야해서 백엔드에 요청이 필요합니다.
-> 현재 disable 해놓은 상태
