### PR TITLE
[민우] - 작성, 상세, 수정 페이지 서버 통신 API 연결 

### DIFF
--- a/src/apis/client/deletePlan.ts
+++ b/src/apis/client/deletePlan.ts
@@ -1,7 +1,9 @@
 import { DOMAIN } from '@/constants/api';
+import { currentMonth } from '@/utils/currentMonth';
 import { axiosInstanceClient } from '../axiosInstanceClient';
 
-// 헤더에 date 추가해줘야 함
 export const deletePlan = (planId: number) => {
-  return axiosInstanceClient.delete(DOMAIN.DELETE_PLANS(planId));
+  return axiosInstanceClient.delete(DOMAIN.DELETE_PLANS(planId), {
+    headers: { Month: currentMonth() },
+  });
 };

--- a/src/apis/client/editPlan.ts
+++ b/src/apis/client/editPlan.ts
@@ -1,7 +1,20 @@
 import { DOMAIN } from '@/constants/api';
+import { EditPlanData } from '@/types/apis/plan/EditPlan';
+import { currentMonth } from '@/utils/currentMonth';
 import { axiosInstanceClient } from '../axiosInstanceClient';
 
-// 헤더에 date 추가해줘야 함
-export const editPlan = (planId: number) => {
-  return axiosInstanceClient.put(DOMAIN.PUT_PLANS(planId));
+interface editPlanProps {
+  planId: number;
+  planData: EditPlanData;
+}
+
+export const editPlan = async ({ planId, planData }: editPlanProps) => {
+  const { data } = await axiosInstanceClient.put(
+    DOMAIN.PUT_PLANS(planId),
+    { data: planData },
+    {
+      headers: { Month: currentMonth() },
+    },
+  );
+  return data;
 };

--- a/src/apis/client/getRemindAfterSeason.ts
+++ b/src/apis/client/getRemindAfterSeason.ts
@@ -1,6 +1,11 @@
 import { DOMAIN } from '@/constants/api';
+import { RemindData } from '@/types/components/Remind';
 import { axiosInstanceClient } from '../axiosInstanceClient';
 
-export const getRemindAfterSeason = (planId: number) => {
-  return axiosInstanceClient.get(DOMAIN.GET_REMINDS(planId));
+export const getRemindAfterSeason = async (planId: number) => {
+  const { data } = await axiosInstanceClient.get<RemindData>(
+    DOMAIN.GET_REMINDS(planId),
+  );
+
+  return data;
 };

--- a/src/apis/client/getRemindAfterSeason.ts
+++ b/src/apis/client/getRemindAfterSeason.ts
@@ -2,10 +2,10 @@ import { DOMAIN } from '@/constants/api';
 import { RemindData } from '@/types/components/Remind';
 import { axiosInstanceClient } from '../axiosInstanceClient';
 
-export const getRemindAfterSeason = async (planId: number) => {
-  const { data } = await axiosInstanceClient.get<RemindData>(
-    DOMAIN.GET_REMINDS(planId),
-  );
+export const getRemindAfterSeason = async (
+  planId: number,
+): Promise<RemindData> => {
+  const { data } = await axiosInstanceClient.get(DOMAIN.GET_REMINDS(planId));
 
   return data;
 };

--- a/src/apis/client/getRemindSeason.ts
+++ b/src/apis/client/getRemindSeason.ts
@@ -2,8 +2,8 @@ import { DOMAIN } from '@/constants/api';
 import { RemindData } from '@/types/components/Remind';
 import { axiosInstanceClient } from '../axiosInstanceClient';
 
-export const getRemindSeason = async (planId: number) => {
-  const { data } = await axiosInstanceClient.get<RemindData>(
+export const getRemindSeason = async (planId: number): Promise<RemindData> => {
+  const { data } = await axiosInstanceClient.get(
     DOMAIN.GET_REMINDS_MODIFY(planId),
   );
 

--- a/src/apis/client/getRemindSeason.ts
+++ b/src/apis/client/getRemindSeason.ts
@@ -1,6 +1,11 @@
 import { DOMAIN } from '@/constants/api';
+import { RemindData } from '@/types/components/Remind';
 import { axiosInstanceClient } from '../axiosInstanceClient';
 
-export const getRemindSeason = (planId: number) => {
-  return axiosInstanceClient.get(DOMAIN.GET_REMINDS_MODIFY(planId));
+export const getRemindSeason = async (planId: number) => {
+  const { data } = await axiosInstanceClient.get<RemindData>(
+    DOMAIN.GET_REMINDS_MODIFY(planId),
+  );
+
+  return data;
 };

--- a/src/apis/client/postNewPlan.ts
+++ b/src/apis/client/postNewPlan.ts
@@ -1,18 +1,6 @@
 import { DOMAIN } from '@/constants/api';
+import { PostNewPlanRequestBody } from '@/types/apis/plan/PostNewPlan';
 import { axiosInstanceClient } from '../axiosInstanceClient';
-
-export interface PostNewPlanRequestBody {
-  title: string;
-  description: string;
-  remindTotalPeriod: number;
-  remindTerm: number;
-  remindDate: number;
-  remindTime: number;
-  isPublic: boolean;
-  tags: string[];
-  messages: string[];
-  icon: number;
-}
 
 export const postNewPlan = async (body: PostNewPlanRequestBody) => {
   const { data } = await axiosInstanceClient.post(DOMAIN.POST_PLANS, {

--- a/src/apis/client/postNewPlan.ts
+++ b/src/apis/client/postNewPlan.ts
@@ -1,7 +1,7 @@
 import { DOMAIN } from '@/constants/api';
 import { axiosInstanceClient } from '../axiosInstanceClient';
 
-interface PostNewPlanRequestBody {
+export interface PostNewPlanRequestBody {
   title: string;
   description: string;
   remindTotalPeriod: number;

--- a/src/app/(header)/create/page.tsx
+++ b/src/app/(header)/create/page.tsx
@@ -15,7 +15,6 @@ import { useCallback, useState } from 'react';
 import './index.scss';
 
 export default function CreatePage() {
-  const { mutate: createNewPlan, isPending } = usePostNewPlanMutation();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [tags, setTags] = useState<string[]>([]);
@@ -96,19 +95,18 @@ export default function CreatePage() {
     setRemindMessageList(updatedList);
   }, [remindMessageList]);
 
-  // 모든 리마인드 메세지가 다 작성되어 있는지 여부
   const isAllRemindMessageExists =
     remindMessageList.length > 0 &&
     remindMessageList.every((remindItem) => remindItem.message.length > 0);
 
-  // 작성 완료 버튼을 누를 수 있는 조건
   const isCreatePossible =
     isAllRemindMessageExists && title.length !== 0 && description.length !== 0;
 
-  // 작성 페이지의 state들을 data에 담아 계획 생성 API를 호출하는함수
+  // 계획 생성 API 부분
+  const { mutate: createNewPlanAPI } = usePostNewPlanMutation();
   const handleCreateNewPlan = () => {
     const data: PostNewPlanRequestBody = {
-      icon: decideRandomIconNumber(),
+      iconNumber: decideRandomIconNumber(),
       isPublic: isPublic,
       title: title,
       description: description,
@@ -121,10 +119,7 @@ export default function CreatePage() {
         return messageItem.message;
       }),
     };
-
-    createNewPlan(data); // 실제 계획 생성 api 호출
-
-    console.log(`로딩 중 : ${isPending}`);
+    createNewPlanAPI(data);
   };
 
   return (

--- a/src/app/(header)/create/page.tsx
+++ b/src/app/(header)/create/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { PostNewPlanRequestBody } from '@/apis/client/postNewPlan';
 import { Button, Modal, WritableRemind } from '@/components';
 import ModalExit from '@/components/Modal/ModalExit';
 import WritablePlan from '@/components/WritablePlan/WritablePlan';
 import { usePostNewPlanMutation } from '@/hooks/apis/usePostNewPlanMutation';
+import { PostNewPlanRequestBody } from '@/types/apis/plan/PostNewPlan';
 import { RemindItemType, RemindOptionType } from '@/types/components/Remind';
+import { changeRemindTimeToString } from '@/utils/changeRemindTimeToString';
 import { decideRandomIconNumber } from '@/utils/decideRandomIconNumber';
 import { decideRemindDate } from '@/utils/decideRemindDate';
 import classNames from 'classnames';
@@ -115,7 +116,7 @@ export default function CreatePage() {
       remindTotalPeriod: remindOptions.TotalPeriod,
       remindTerm: remindOptions.Term,
       remindDate: remindOptions.Date,
-      remindTime: remindOptions.Time,
+      remindTime: changeRemindTimeToString(remindOptions.Time),
       messages: remindMessageList.map((messageItem) => {
         return messageItem.message;
       }),

--- a/src/app/(header)/create/page.tsx
+++ b/src/app/(header)/create/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import { PostNewPlanRequestBody } from '@/apis/client/postNewPlan';
 import { Button, Modal, WritableRemind } from '@/components';
 import ModalExit from '@/components/Modal/ModalExit';
 import WritablePlan from '@/components/WritablePlan/WritablePlan';
+import { usePostNewPlanMutation } from '@/hooks/apis/usePostNewPlanMutation';
 import { RemindItemType, RemindOptionType } from '@/types/components/Remind';
 import { decideRandomIconNumber } from '@/utils/decideRandomIconNumber';
 import { decideRemindDate } from '@/utils/decideRemindDate';
@@ -11,20 +13,8 @@ import Link from 'next/link';
 import { useCallback, useState } from 'react';
 import './index.scss';
 
-type createPlanData = {
-  title: string;
-  description: string;
-  remindTotalPeriod: number;
-  remindTerm: number;
-  remindDate: number;
-  remindTime: number;
-  isPublic: boolean;
-  tags: string[];
-  messages: string[];
-  icon: number;
-};
-
 export default function CreatePage() {
+  const { mutate: createNewPlan, isPending } = usePostNewPlanMutation();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [tags, setTags] = useState<string[]>([]);
@@ -105,9 +95,18 @@ export default function CreatePage() {
     setRemindMessageList(updatedList);
   }, [remindMessageList]);
 
-  // 작성 페이지의 state들을 createPlandata에 담아 계획 생성 API를 호출하는함수
-  const createNewPlan = () => {
-    const data: createPlanData = {
+  // 모든 리마인드 메세지가 다 작성되어 있는지 여부
+  const isAllRemindMessageExists =
+    remindMessageList.length > 0 &&
+    remindMessageList.every((remindItem) => remindItem.message.length > 0);
+
+  // 작성 완료 버튼을 누를 수 있는 조건
+  const isCreatePossible =
+    isAllRemindMessageExists && title.length !== 0 && description.length !== 0;
+
+  // 작성 페이지의 state들을 data에 담아 계획 생성 API를 호출하는함수
+  const handleCreateNewPlan = () => {
+    const data: PostNewPlanRequestBody = {
       icon: decideRandomIconNumber(),
       isPublic: isPublic,
       title: title,
@@ -122,17 +121,10 @@ export default function CreatePage() {
       }),
     };
 
-    console.log(`작성 페이지의 state를 이용해 새 계획 생성 API 호출 : ${data}`);
+    createNewPlan(data); // 실제 계획 생성 api 호출
+
+    console.log(`로딩 중 : ${isPending}`);
   };
-
-  // 모든 리마인드 메세지가 다 작성되어 있는지 여부
-  const isAllRemindMessageExists =
-    remindMessageList.length > 0 &&
-    remindMessageList.every((remindItem) => remindItem.message.length > 0);
-
-  // 작성 완료 버튼을 누를 수 있는 조건
-  const isCreatePossible =
-    isAllRemindMessageExists && title.length !== 0 && description.length !== 0;
 
   return (
     <div className={classNames('create-page')}>
@@ -165,7 +157,7 @@ export default function CreatePage() {
             size="lg"
             border={false}
             onClick={() => {
-              createNewPlan();
+              handleCreateNewPlan();
             }}
             disabled={!isCreatePossible}>
             작성 완료

--- a/src/app/(header)/edit/[planId]/page.tsx
+++ b/src/app/(header)/edit/[planId]/page.tsx
@@ -8,6 +8,8 @@ import { useEditPlanMutation } from '@/hooks/apis/useEditPlanMutation';
 import { useGetRemindQuery } from '@/hooks/apis/useGetRemindQuery';
 import { EditPlanData } from '@/types/apis/plan/EditPlan';
 import { RemindItemType, RemindOptionType } from '@/types/components/Remind';
+import { changeRemindTimeToNumber } from '@/utils/changeRemindTimeToNumber';
+import { changeRemindTimeToString } from '@/utils/changeRemindTimeToString';
 import { checkIsSeason } from '@/utils/checkIsSeason';
 import { decideRemindDate } from '@/utils/decideRemindDate';
 import classNames from 'classnames';
@@ -39,64 +41,6 @@ export default function EditPage({ params }: { params: { planId: string } }) {
     checkIsSeason(),
   );
 
-  // const remindData: RemindData = {
-  //   isRemindable: true,
-  //   remindTime: 9,
-  //   remindDate: 1,
-  //   remindTerm: 1,
-  //   remindTotalPeriod: 12,
-  //   remindMessageList: [
-  //     {
-  //       remindMonth: 3,
-  //       remindDate: 15,
-  //       remindMessage: '리마인드 받았지만 만료되서 피드백 0%로 처리 ',
-  //       isReminded: true,
-  //       isFeedback: false,
-  //       feedbackId: 12,
-  //       rate: 0,
-  //       isExpired: true,
-  //       endMonth: 12,
-  //       endDate: 1,
-  //     },
-  //     {
-  //       remindMonth: 6,
-  //       remindDate: 15,
-  //       remindMessage: '리마인드 받아서 피드백함',
-  //       isReminded: true,
-  //       isFeedback: true,
-  //       feedbackId: 12,
-  //       rate: 75,
-  //       isExpired: true,
-  //       endMonth: 12,
-  //       endDate: 1,
-  //     },
-  //     {
-  //       remindMonth: 9,
-  //       remindDate: 15,
-  //       remindMessage: '예시',
-  //       isReminded: true,
-  //       isFeedback: false,
-  //       feedbackId: 12,
-  //       rate: 0,
-  //       isExpired: false,
-  //       endMonth: 12,
-  //       endDate: 1,
-  //     },
-  //     {
-  //       remindMonth: 12,
-  //       remindDate: 15,
-  //       remindMessage: '예시',
-  //       isReminded: false,
-  //       isFeedback: false,
-  //       feedbackId: 12,
-  //       rate: 0,
-  //       isExpired: false,
-  //       endMonth: 12,
-  //       endDate: 1,
-  //     },
-  //   ],
-  // };
-
   // 2. 계획 수정을 위해 관리되어야 하는 state 및 핸들러의 기본값에 1번에서 받은 값을 넣어준다.
   const [title, setTitle] = useState(planData.title);
   const [description, setDescription] = useState(planData.description);
@@ -119,7 +63,7 @@ export default function EditPage({ params }: { params: { planId: string } }) {
     TotalPeriod: remindData.remindTotalPeriod,
     Term: remindData.remindTerm,
     Date: remindData.remindDate,
-    Time: remindData.remindTime,
+    Time: changeRemindTimeToNumber(remindData.remindTime),
   });
 
   const handleChangeRemindOption = (
@@ -212,7 +156,7 @@ export default function EditPage({ params }: { params: { planId: string } }) {
       remindTotalPeriod: remindOptions.TotalPeriod,
       remindTerm: remindOptions.Term,
       remindDate: remindOptions.Date,
-      remindTime: remindOptions.Time,
+      remindTime: changeRemindTimeToString(remindOptions.Time),
       isPublic: isPublic,
       canRemind: isRemindOn,
       canAjaja: canAjaja,
@@ -222,7 +166,7 @@ export default function EditPage({ params }: { params: { planId: string } }) {
       }),
     };
 
-    editPlanAPI({ planId: parseInt(planId, 10), planData: editPlanData }); // 계획 수정 API 호출
+    editPlanAPI({ planId: parseInt(planId, 10), planData: editPlanData });
 
     console.log(`${planId}에 해당하는 계획 수정 API 호출 `);
   };

--- a/src/app/(header)/edit/[planId]/page.tsx
+++ b/src/app/(header)/edit/[planId]/page.tsx
@@ -4,11 +4,9 @@ import { Button, Modal, WritableRemind } from '@/components';
 import ModalExit from '@/components/Modal/ModalExit';
 import { PlanData } from '@/components/ReadOnlyPlan/ReadOnlyPlan';
 import WritablePlan from '@/components/WritablePlan/WritablePlan';
-import {
-  RemindData,
-  RemindItemType,
-  RemindOptionType,
-} from '@/types/components/Remind';
+import { useGetRemindQuery } from '@/hooks/apis/useGetRemindQuery';
+import { RemindItemType, RemindOptionType } from '@/types/components/Remind';
+import { checkIsSeason } from '@/utils/checkIsSeason';
 import { decideRemindDate } from '@/utils/decideRemindDate';
 import classNames from 'classnames';
 import Link from 'next/link';
@@ -40,70 +38,76 @@ export default function EditPage({ params }: { params: { planId: string } }) {
     title: '계획 제목 테스트',
     description: '계획 설명 테스트',
     isPublic: true,
-    tags: ['태그1', '태그1', '태그1', '태그1', '태그1'],
+    tags: ['태그1', '태그2', '태그3', '태그4', '태그5'],
     ajajas: 100,
     isAjajaOn: true,
     isCanAjaja: true,
     createdAt: '2023-06-15',
   };
 
-  const remindData: RemindData = {
-    isRemindable: true,
-    remindTime: 9,
-    remindDate: 1,
-    remindTerm: 1,
-    remindTotalPeriod: 12,
-    remindMessageList: [
-      {
-        remindMonth: 3,
-        remindDate: 15,
-        remindMessage: '리마인드 받았지만 만료되서 피드백 0%로 처리 ',
-        isReminded: true,
-        isFeedback: false,
-        feedbackId: 12,
-        rate: 0,
-        isExpired: true,
-        endMonth: 12,
-        endDate: 1,
-      },
-      {
-        remindMonth: 6,
-        remindDate: 15,
-        remindMessage: '리마인드 받아서 피드백함',
-        isReminded: true,
-        isFeedback: true,
-        feedbackId: 12,
-        rate: 75,
-        isExpired: true,
-        endMonth: 12,
-        endDate: 1,
-      },
-      {
-        remindMonth: 9,
-        remindDate: 15,
-        remindMessage: '예시',
-        isReminded: true,
-        isFeedback: false,
-        feedbackId: 12,
-        rate: 0,
-        isExpired: false,
-        endMonth: 12,
-        endDate: 1,
-      },
-      {
-        remindMonth: 12,
-        remindDate: 15,
-        remindMessage: '예시',
-        isReminded: false,
-        isFeedback: false,
-        feedbackId: 12,
-        rate: 0,
-        isExpired: false,
-        endMonth: 12,
-        endDate: 1,
-      },
-    ],
-  };
+  // 리마인드 정보 조회 API 호출해서 받아온 data
+  const { remindData } = useGetRemindQuery(
+    parseInt(planId, 10),
+    checkIsSeason(),
+  );
+
+  // const remindData: RemindData = {
+  //   isRemindable: true,
+  //   remindTime: 9,
+  //   remindDate: 1,
+  //   remindTerm: 1,
+  //   remindTotalPeriod: 12,
+  //   remindMessageList: [
+  //     {
+  //       remindMonth: 3,
+  //       remindDate: 15,
+  //       remindMessage: '리마인드 받았지만 만료되서 피드백 0%로 처리 ',
+  //       isReminded: true,
+  //       isFeedback: false,
+  //       feedbackId: 12,
+  //       rate: 0,
+  //       isExpired: true,
+  //       endMonth: 12,
+  //       endDate: 1,
+  //     },
+  //     {
+  //       remindMonth: 6,
+  //       remindDate: 15,
+  //       remindMessage: '리마인드 받아서 피드백함',
+  //       isReminded: true,
+  //       isFeedback: true,
+  //       feedbackId: 12,
+  //       rate: 75,
+  //       isExpired: true,
+  //       endMonth: 12,
+  //       endDate: 1,
+  //     },
+  //     {
+  //       remindMonth: 9,
+  //       remindDate: 15,
+  //       remindMessage: '예시',
+  //       isReminded: true,
+  //       isFeedback: false,
+  //       feedbackId: 12,
+  //       rate: 0,
+  //       isExpired: false,
+  //       endMonth: 12,
+  //       endDate: 1,
+  //     },
+  //     {
+  //       remindMonth: 12,
+  //       remindDate: 15,
+  //       remindMessage: '예시',
+  //       isReminded: false,
+  //       isFeedback: false,
+  //       feedbackId: 12,
+  //       rate: 0,
+  //       isExpired: false,
+  //       endMonth: 12,
+  //       endDate: 1,
+  //     },
+  //   ],
+  // };
 
   // 2. 계획 수정을 위해 관리되어야 하는 state 및 핸들러의 기본값에 1번에서 받은 값을 넣어준다.
   const [title, setTitle] = useState(planData.title);

--- a/src/app/(header)/edit/[planId]/page.tsx
+++ b/src/app/(header)/edit/[planId]/page.tsx
@@ -4,7 +4,9 @@ import { Button, Modal, WritableRemind } from '@/components';
 import ModalExit from '@/components/Modal/ModalExit';
 import { PlanData } from '@/components/ReadOnlyPlan/ReadOnlyPlan';
 import WritablePlan from '@/components/WritablePlan/WritablePlan';
+import { useEditPlanMutation } from '@/hooks/apis/useEditPlanMutation';
 import { useGetRemindQuery } from '@/hooks/apis/useGetRemindQuery';
+import { EditPlanData } from '@/types/apis/plan/EditPlan';
 import { RemindItemType, RemindOptionType } from '@/types/components/Remind';
 import { checkIsSeason } from '@/utils/checkIsSeason';
 import { decideRemindDate } from '@/utils/decideRemindDate';
@@ -13,24 +15,10 @@ import Link from 'next/link';
 import { useCallback, useState } from 'react';
 import './index.scss';
 
-type EditPlanData = {
-  title: string;
-  description: string;
-  remindTotalPeriod: number;
-  remindTerm: number;
-  remindDate: number;
-  remindTime: number;
-  isPublic: boolean;
-  canRemind: boolean;
-  canAjaja: boolean;
-  tags: string[];
-  messages: string[];
-};
-
 export default function EditPage({ params }: { params: { planId: string } }) {
   const { planId } = params;
 
-  // 1. 서버에서 planId에 해당하는 계획, 리마인드 data 받아오기
+  // 1-1. 계획 단건 조회 API를 통해 계획 data 받아오기
   const planData: PlanData = {
     id: 123,
     userId: 123,
@@ -45,7 +33,7 @@ export default function EditPage({ params }: { params: { planId: string } }) {
     createdAt: '2023-06-15',
   };
 
-  // 리마인드 정보 조회 API 호출해서 받아온 data
+  // 1-2. 리마인드 정보 조회 API 호출해서 받아온 data 받아오기
   const { remindData } = useGetRemindQuery(
     parseInt(planId, 10),
     checkIsSeason(),
@@ -215,6 +203,8 @@ export default function EditPage({ params }: { params: { planId: string } }) {
     isAllRemindMessageExists && title.length !== 0 && description.length !== 0;
 
   // 3. 수정된 state들을 가지고 호출하는 계획 수정 API
+  const { mutate: editPlanAPI } = useEditPlanMutation();
+
   const editPlan = () => {
     const editPlanData: EditPlanData = {
       title: title,
@@ -232,9 +222,9 @@ export default function EditPage({ params }: { params: { planId: string } }) {
       }),
     };
 
-    console.log(
-      `${planId}에 해당하는 계획을 ${editPlanData}의 data로 수정하는 계획 수정 API 호출 `,
-    );
+    editPlanAPI({ planId: parseInt(planId, 10), planData: editPlanData }); // 계획 수정 API 호출
+
+    console.log(`${planId}에 해당하는 계획 수정 API 호출 `);
   };
 
   return (

--- a/src/app/(header)/plans/[planId]/page.tsx
+++ b/src/app/(header)/plans/[planId]/page.tsx
@@ -12,11 +12,12 @@ import { useDeletePlanMutation } from '@/hooks/apis/useDeletePlanMutation';
 import { checkIsSeason } from '@/utils/checkIsSeason';
 import classNames from 'classnames';
 import Link from 'next/link';
-import { useRouter } from 'next/router';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import './index.scss';
 
 export default function PlanIdPage({ params }: { params: { planId: string } }) {
+  const router = useRouter();
   // TODO: 계획 단건 조회 API 구현 후 리액트 쿼리 훅에서 받아오는 걸로 변경하기
   const planData: PlanData = {
     id: 2342342,
@@ -49,8 +50,6 @@ export default function PlanIdPage({ params }: { params: { planId: string } }) {
   const handleModalClickNo = () => {
     setIsDeletePlanModalOpen(false);
   };
-
-  const router = useRouter();
 
   return (
     <div className={classNames('plans-page')}>

--- a/src/app/(header)/plans/[planId]/page.tsx
+++ b/src/app/(header)/plans/[planId]/page.tsx
@@ -33,8 +33,8 @@ export default function PlanIdPage({ params }: { params: { planId: string } }) {
   };
 
   const { planId } = params;
-  const isMyPlan = true; // TODO: 쿠키에 있는 토큰을 decode해서 userId를 받아온 후, planData의 userId와 비교해야 함
   const isSeason = checkIsSeason();
+  const isMyPlan = true; // TODO: 쿠키에 있는 토큰을 decode해서 userId를 받아온 후, planData의 userId와 비교해야 함
 
   const [isDeletePlanModalOpen, setIsDeletePlanModalOpen] = useState(false);
 

--- a/src/app/(header)/plans/[planId]/page.tsx
+++ b/src/app/(header)/plans/[planId]/page.tsx
@@ -16,9 +16,24 @@ import './index.scss';
 
 export default function PlanIdPage({ params }: { params: { planId: string } }) {
   // 계획 단건 조회로 계획 데이터 받아와 계획 컴포넌트 렌러링
-  // 계획 data안 userId와 현재 유저의 userId 비교해서 내 계획인지 여부인 isMyPlan 값 할당
+  // TODO : 노철님이 구현하시면 리액트 쿼리 훅에서 받아오는 걸로 변경하기
+
+  const planData: PlanData = {
+    id: 2342342,
+    userId: 2342342,
+    nickname: '유저 닉네임',
+    title: '계획 내용 테스트 ',
+    description: '계획 설명',
+    isPublic: true,
+    tags: ['태그1', '태그2', '태그3', '태그4', '태그5'],
+    ajajas: 32343,
+    isAjajaOn: true,
+    isCanAjaja: false,
+    createdAt: '2023-06-15',
+  };
+
   const { planId } = params;
-  const isMyPlan = true;
+  const isMyPlan = true; // 쿠키에 잇는 토큰을 decode해서 userId를 받아온 후, planData의 userId와 비교해야 함
   const isSeason = checkIsSeason();
 
   const [isDeletePlanModalOpen, setIsDeletePlanModalOpen] = useState(false);
@@ -34,20 +49,6 @@ export default function PlanIdPage({ params }: { params: { planId: string } }) {
 
   const deletePlanAPI = (planId: string) => {
     console.log(`${planId}에 해당하는 계획 삭제 API 호출 `);
-  };
-
-  const planData: PlanData = {
-    id: 2342342,
-    userId: 2342342,
-    nickname: '유저 닉네임',
-    title: '계획 내용 테스트 ',
-    description: '계획 설명',
-    isPublic: true,
-    tags: ['태그1', '태그2', '태그3', '태그4', '태그5'],
-    ajajas: 32343,
-    isAjajaOn: true,
-    isCanAjaja: false,
-    createdAt: '2023-06-15',
   };
 
   return (

--- a/src/app/(header)/plans/[planId]/page.tsx
+++ b/src/app/(header)/plans/[planId]/page.tsx
@@ -8,16 +8,16 @@ import {
   ReadOnlyRemind,
 } from '@/components';
 import { PlanData } from '@/components/ReadOnlyPlan/ReadOnlyPlan';
+import { useDeletePlanMutation } from '@/hooks/apis/useDeletePlanMutation';
 import { checkIsSeason } from '@/utils/checkIsSeason';
 import classNames from 'classnames';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { useState } from 'react';
 import './index.scss';
 
 export default function PlanIdPage({ params }: { params: { planId: string } }) {
-  // 계획 단건 조회로 계획 데이터 받아와 계획 컴포넌트 렌러링
-  // TODO : 노철님이 구현하시면 리액트 쿼리 훅에서 받아오는 걸로 변경하기
-
+  // TODO: 계획 단건 조회 API 구현 후 리액트 쿼리 훅에서 받아오는 걸로 변경하기
   const planData: PlanData = {
     id: 2342342,
     userId: 2342342,
@@ -33,23 +33,24 @@ export default function PlanIdPage({ params }: { params: { planId: string } }) {
   };
 
   const { planId } = params;
-  const isMyPlan = true; // 쿠키에 잇는 토큰을 decode해서 userId를 받아온 후, planData의 userId와 비교해야 함
+  const isMyPlan = true; // TODO: 쿠키에 있는 토큰을 decode해서 userId를 받아온 후, planData의 userId와 비교해야 함
   const isSeason = checkIsSeason();
 
   const [isDeletePlanModalOpen, setIsDeletePlanModalOpen] = useState(false);
 
+  const { mutate: deletePlanAPI } = useDeletePlanMutation();
+
   const handleModalClickYes = () => {
     setIsDeletePlanModalOpen(false);
-    deletePlanAPI(planId);
+    deletePlanAPI(parseInt(planId, 10));
+    router.back(); // 계획 삭제 했으니 상세 페이지 이전으로 1단계 이동 시켜줘야 함
   };
 
   const handleModalClickNo = () => {
     setIsDeletePlanModalOpen(false);
   };
 
-  const deletePlanAPI = (planId: string) => {
-    console.log(`${planId}에 해당하는 계획 삭제 API 호출 `);
-  };
+  const router = useRouter();
 
   return (
     <div className={classNames('plans-page')}>

--- a/src/app/(header)/plans/[planId]/page.tsx
+++ b/src/app/(header)/plans/[planId]/page.tsx
@@ -18,7 +18,8 @@ import './index.scss';
 
 export default function PlanIdPage({ params }: { params: { planId: string } }) {
   const router = useRouter();
-  // TODO: 계획 단건 조회 API 구현 후 리액트 쿼리 훅에서 받아오는 걸로 변경하기
+
+  // TODO: 1. 계획 단건 조회 API를 통해 받아오는 걸로 변경
   const planData: PlanData = {
     id: 2342342,
     userId: 2342342,
@@ -35,7 +36,7 @@ export default function PlanIdPage({ params }: { params: { planId: string } }) {
 
   const { planId } = params;
   const isSeason = checkIsSeason();
-  const isMyPlan = true; // TODO: 쿠키에 있는 토큰을 decode해서 userId를 받아온 후, planData의 userId와 비교해야 함
+  const isMyPlan = true; // TODO: 2. 쿠키에 있는 토큰을 decode해서 userId를 받아온 후, 1번 planData의 userId와 비교해야 함
 
   const [isDeletePlanModalOpen, setIsDeletePlanModalOpen] = useState(false);
 
@@ -44,7 +45,7 @@ export default function PlanIdPage({ params }: { params: { planId: string } }) {
   const handleModalClickYes = () => {
     setIsDeletePlanModalOpen(false);
     deletePlanAPI(parseInt(planId, 10));
-    router.back(); // 계획 삭제 했으니 상세 페이지 이전으로 1단계 이동 시켜줘야 함
+    router.back(); // 계획 삭제 했으니 상세 페이지 이전으로 1단계 이동
   };
 
   const handleModalClickNo = () => {

--- a/src/components/ReadOnlyPlan/ReadOnlyPlan.tsx
+++ b/src/components/ReadOnlyPlan/ReadOnlyPlan.tsx
@@ -1,3 +1,5 @@
+import { useToggleAjajaNotificationMutation } from '@/hooks/apis/useToggleAjajaNotificationMutation';
+import { useToggleIsPublicMutation } from '@/hooks/apis/useToggleIsPublicMutation';
 import { Color } from '@/types';
 import classNames from 'classnames';
 import { AjajaButton, IconSwitchButton, PlanInput, Tag } from '..';
@@ -44,12 +46,20 @@ export default function ReadOnlyPlan({ isMine, planData }: ReadOnlyPlanProps) {
     'blue-300',
     'purple-300',
   ];
+  const { mutate: toggleIsPublic } = useToggleIsPublicMutation();
+  const { mutate: toggleAjajaNotification } =
+    useToggleAjajaNotificationMutation();
+
   const handleToggleIsPublic = () => {
+    toggleIsPublic(id);
     console.log(`${id}를 통해서 공개여부 변경`);
   };
+
   const handleToggleIsCanAjaja = () => {
+    toggleAjajaNotification(id);
     console.log(`${id}를 통해서 응원메세지 알림여부 변경`);
   };
+
   return (
     <div className="plan__container">
       <div className="plan__header">

--- a/src/components/Remind/ReadOnlyRemind/ReadOnlyRemind.tsx
+++ b/src/components/Remind/ReadOnlyRemind/ReadOnlyRemind.tsx
@@ -2,6 +2,7 @@
 
 import { ReadOnlyRemindItem } from '@/components';
 import DebounceSwitchButton from '@/components/DebounceSwitchButton/DebounceSwitchButton';
+import { useToggleIsRemindableMutation } from '@/hooks/apis/useToggleIsRemindable';
 import { RemindData, RemindOptionObjectType } from '@/types/components/Remind';
 import classNames from 'classnames';
 import React from 'react';
@@ -104,7 +105,10 @@ export default function ReadOnlyRemind({ planId }: ReadOnlyRemindProps) {
     remindMessageList,
   } = remindData;
 
+  const { mutate: toggleIsRemindableAPI } = useToggleIsRemindableMutation();
+
   const handleToggleIsRemindable = () => {
+    toggleIsRemindableAPI(parseInt(planId, 10));
     console.log(`${planId}에 대한 리마인드 알림 여부 toggle API호출 `);
   };
 

--- a/src/components/Remind/ReadOnlyRemind/ReadOnlyRemind.tsx
+++ b/src/components/Remind/ReadOnlyRemind/ReadOnlyRemind.tsx
@@ -2,9 +2,11 @@
 
 import { ReadOnlyRemindItem } from '@/components';
 import DebounceSwitchButton from '@/components/DebounceSwitchButton/DebounceSwitchButton';
+import { useGetRemindQuery } from '@/hooks/apis/useGetRemindQuery';
 import { useToggleIsRemindableMutation } from '@/hooks/apis/useToggleIsRemindable';
-import { RemindData, RemindOptionObjectType } from '@/types/components/Remind';
+import { RemindOptionObjectType } from '@/types/components/Remind';
 import { changeRemindTimeToNumber } from '@/utils/changeRemindTimeToNumber';
+import { checkIsSeason } from '@/utils/checkIsSeason';
 import classNames from 'classnames';
 import React from 'react';
 import {
@@ -33,78 +35,10 @@ const makeRemindOptionToString = (
 
 export default function ReadOnlyRemind({ planId }: ReadOnlyRemindProps) {
   // 리마인드 정보 조회 API 호출해서 받아온 data
-
-  // const { data: serverRemindData, isLoading } = useGetRemindQuery(
-  //   parseInt(planId, 10),
-  //   checkIsSeason(),
-  // );
-
-  const remindData: RemindData = {
-    isRemindable: true,
-    remindTime: 'Morning',
-    remindDate: 1,
-    remindTerm: 1,
-    remindTotalPeriod: 12,
-    remindMessageList: [
-      {
-        remindMonth: 3,
-        remindDate: 15,
-        remindMessage: '리마인드 받았지만 만료되서 피드백 0%로 처리 ',
-        isReminded: true,
-        isFeedback: false,
-        feedbackId: 12,
-        rate: 0,
-        isExpired: true,
-        endMonth: 12,
-        endDate: 1,
-      },
-      {
-        remindMonth: 6,
-        remindDate: 15,
-        remindMessage: '리마인드 받아서 피드백함',
-        isReminded: true,
-        isFeedback: true,
-        feedbackId: 12,
-        rate: 75,
-        isExpired: true,
-        endMonth: 12,
-        endDate: 1,
-      },
-      {
-        remindMonth: 9,
-        remindDate: 15,
-        remindMessage: '예시',
-        isReminded: true,
-        isFeedback: false,
-        feedbackId: 12,
-        rate: 0,
-        isExpired: false,
-        endMonth: 12,
-        endDate: 1,
-      },
-      {
-        remindMonth: 12,
-        remindDate: 15,
-        remindMessage: '예시',
-        isReminded: false,
-        isFeedback: false,
-        feedbackId: 12,
-        rate: 0,
-        isExpired: false,
-        endMonth: 12,
-        endDate: 1,
-      },
-    ],
-  };
-
-  const {
-    isRemindable,
-    remindTime,
-    remindDate,
-    remindTerm,
-    remindTotalPeriod,
-    remindMessageList,
-  } = remindData;
+  const { remindData } = useGetRemindQuery(
+    parseInt(planId, 10),
+    checkIsSeason(),
+  );
 
   const { mutate: toggleIsRemindableAPI } = useToggleIsRemindableMutation();
 
@@ -120,7 +54,7 @@ export default function ReadOnlyRemind({ planId }: ReadOnlyRemindProps) {
           리마인드
         </span>
         <DebounceSwitchButton
-          defaultIsOn={isRemindable}
+          defaultIsOn={remindData.isRemindable}
           submitToggleAPI={handleToggleIsRemindable}
           toggleName="remind"
         />
@@ -128,24 +62,27 @@ export default function ReadOnlyRemind({ planId }: ReadOnlyRemindProps) {
 
       <div className={classNames('readonly-remind__options')}>
         <span className={classNames('readonly-remind__options__option')}>
-          {makeRemindOptionToString(TOTAL_PERIOD_OPTIONS, remindTotalPeriod)}
+          {makeRemindOptionToString(
+            TOTAL_PERIOD_OPTIONS,
+            remindData.remindTotalPeriod,
+          )}
         </span>
         <span className={classNames('readonly-remind__options__text')}>
           동안
         </span>
 
         <span className={classNames('readonly-remind__options__option')}>
-          {makeRemindOptionToString(TERM_OPTIONS, remindTerm)}
+          {makeRemindOptionToString(TERM_OPTIONS, remindData.remindTerm)}
         </span>
         <span>마다 매달</span>
 
         <span className={classNames('readonly-remind__options__option')}>
-          {makeRemindOptionToString(DATE_OPTIONS, remindDate)}
+          {makeRemindOptionToString(DATE_OPTIONS, remindData.remindDate)}
         </span>
         <span className={classNames('readonly-remind__options__option')}>
           {makeRemindOptionToString(
             TIME_OPTIONS,
-            changeRemindTimeToNumber(remindTime),
+            changeRemindTimeToNumber(remindData.remindTime),
           )}
         </span>
         <span className={classNames('readonly-remind__options__text')}>
@@ -153,9 +90,9 @@ export default function ReadOnlyRemind({ planId }: ReadOnlyRemindProps) {
         </span>
       </div>
 
-      {remindMessageList.length !== 0 && (
+      {remindData.remindMessageList.length !== 0 && (
         <ul className={classNames('readonly-remind__message__list')}>
-          {remindMessageList.map((item, index) => {
+          {remindData.remindMessageList.map((item, index) => {
             return (
               <ReadOnlyRemindItem
                 key={index}

--- a/src/components/Remind/ReadOnlyRemind/ReadOnlyRemind.tsx
+++ b/src/components/Remind/ReadOnlyRemind/ReadOnlyRemind.tsx
@@ -4,6 +4,7 @@ import { ReadOnlyRemindItem } from '@/components';
 import DebounceSwitchButton from '@/components/DebounceSwitchButton/DebounceSwitchButton';
 import { useToggleIsRemindableMutation } from '@/hooks/apis/useToggleIsRemindable';
 import { RemindData, RemindOptionObjectType } from '@/types/components/Remind';
+import { changeRemindTimeToNumber } from '@/utils/changeRemindTimeToNumber';
 import classNames from 'classnames';
 import React from 'react';
 import {
@@ -40,7 +41,7 @@ export default function ReadOnlyRemind({ planId }: ReadOnlyRemindProps) {
 
   const remindData: RemindData = {
     isRemindable: true,
-    remindTime: 9,
+    remindTime: 'Morning',
     remindDate: 1,
     remindTerm: 1,
     remindTotalPeriod: 12,
@@ -142,7 +143,10 @@ export default function ReadOnlyRemind({ planId }: ReadOnlyRemindProps) {
           {makeRemindOptionToString(DATE_OPTIONS, remindDate)}
         </span>
         <span className={classNames('readonly-remind__options__option')}>
-          {makeRemindOptionToString(TIME_OPTIONS, remindTime)}
+          {makeRemindOptionToString(
+            TIME_OPTIONS,
+            changeRemindTimeToNumber(remindTime),
+          )}
         </span>
         <span className={classNames('readonly-remind__options__text')}>
           에 리마인드를 받고 있어요 !

--- a/src/components/Remind/ReadOnlyRemind/ReadOnlyRemind.tsx
+++ b/src/components/Remind/ReadOnlyRemind/ReadOnlyRemind.tsx
@@ -18,7 +18,7 @@ interface ReadOnlyRemindProps {
 }
 
 // 선택된 리마인드 옵션에 따라 이에 해당하는 text를 return 해주는 함수
-export const makeRemindOptionToString = (
+const makeRemindOptionToString = (
   remindOptions: RemindOptionObjectType[],
   selectedValue: number,
 ) => {
@@ -106,10 +106,6 @@ export default function ReadOnlyRemind({ planId }: ReadOnlyRemindProps) {
 
   const handleToggleIsRemindable = () => {
     console.log(`${planId}에 대한 리마인드 알림 여부 toggle API호출 `);
-    console
-      .log
-      // `서버에서 받아온 data : ${serverRemindData}, isLoading: ${isLoading}`,
-      ();
   };
 
   return (

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -34,8 +34,8 @@ export const DOMAIN = {
   GET_PLANS_FEEDBAKS: (planId: number) => `/plans/${planId}/feedbacks`,
   GET_PLANS_MAIN: (userId: number) => `/mock/plans/main/${userId}`,
 
-  GET_REMINDS: (planId: number) => `/reminds/${planId}`,
-  GET_REMINDS_MODIFY: (planId: number) => `/reminds/modify/${planId}`,
+  GET_REMINDS: (planId: number) => `/mock/reminds/${planId}`,
+  GET_REMINDS_MODIFY: (planId: number) => `/mock/reminds/modify/${planId}`,
 };
 
 //실제 API -> swagger 순서입니다.

--- a/src/hooks/apis/useGetRemindQuery.ts
+++ b/src/hooks/apis/useGetRemindQuery.ts
@@ -3,10 +3,12 @@ import { getRemindSeason } from '@/apis/client/getRemindSeason';
 import { useQuery } from '@tanstack/react-query';
 
 export const useGetRemindQuery = (planId: number, isSeason: boolean) => {
-  return useQuery({
-    queryKey: ['getRemind', planId], // plan 마다 캐시 관리 ?
+  const { data } = useQuery({
+    queryKey: ['getRemind', planId], // TODO: plan 마다 캐시 관리 ?
     queryFn: () => {
       return isSeason ? getRemindSeason(planId) : getRemindAfterSeason(planId);
     },
   });
+
+  return { remindData: data! };
 };

--- a/src/hooks/apis/usePostNewPlanMutation.ts
+++ b/src/hooks/apis/usePostNewPlanMutation.ts
@@ -6,7 +6,3 @@ export const usePostNewPlanMutation = () => {
     mutationFn: postNewPlan,
   });
 };
-
-// 사용 예시
-// const { mutate: 쓰고싶은이름명, isLoading: 쓰고싶은이름명, } = usePostNewPlanMutation();
-// onSuccess에 내 계획 정보 조  회 refetch 위해 invalidQueries?

--- a/src/types/apis/plan/EditPlan.ts
+++ b/src/types/apis/plan/EditPlan.ts
@@ -4,7 +4,7 @@ export interface EditPlanData {
   remindTotalPeriod: number;
   remindTerm: number;
   remindDate: number;
-  remindTime: number;
+  remindTime: 'Morning' | 'Afternoon' | 'Evening';
   isPublic: boolean;
   canRemind: boolean;
   canAjaja: boolean;

--- a/src/types/apis/plan/EditPlan.ts
+++ b/src/types/apis/plan/EditPlan.ts
@@ -1,0 +1,13 @@
+export interface EditPlanData {
+  title: string;
+  description: string;
+  remindTotalPeriod: number;
+  remindTerm: number;
+  remindDate: number;
+  remindTime: number;
+  isPublic: boolean;
+  canRemind: boolean;
+  canAjaja: boolean;
+  tags: string[];
+  messages: string[];
+}

--- a/src/types/apis/plan/PostNewPlan.ts
+++ b/src/types/apis/plan/PostNewPlan.ts
@@ -8,5 +8,5 @@ export interface PostNewPlanRequestBody {
   isPublic: boolean;
   tags: string[];
   messages: string[];
-  icon: number;
+  iconNumber: number;
 }

--- a/src/types/apis/plan/PostNewPlan.ts
+++ b/src/types/apis/plan/PostNewPlan.ts
@@ -1,0 +1,12 @@
+export interface PostNewPlanRequestBody {
+  title: string;
+  description: string;
+  remindTotalPeriod: number;
+  remindTerm: number;
+  remindDate: number;
+  remindTime: 'Morning' | 'Afternoon' | 'Evening';
+  isPublic: boolean;
+  tags: string[];
+  messages: string[];
+  icon: number;
+}

--- a/src/types/components/Remind.ts
+++ b/src/types/components/Remind.ts
@@ -7,7 +7,7 @@ export type RemindOptionType = {
   TotalPeriod: number;
   Term: number;
   Date: number;
-  Time: number;
+  Time: 9 | 13 | 20;
 };
 
 export interface RemindItemType {
@@ -33,7 +33,7 @@ export interface ReadOnlyRemindItemData {
 
 export interface RemindData {
   isRemindable: boolean;
-  remindTime: number;
+  remindTime: 'Morning' | 'Afternoon' | 'Evening';
   remindDate: number;
   remindTerm: number;
   remindTotalPeriod: number;

--- a/src/utils/changeRemindTimeToNumber.ts
+++ b/src/utils/changeRemindTimeToNumber.ts
@@ -1,0 +1,12 @@
+export const changeRemindTimeToNumber = (
+  remindTime: 'Morning' | 'Afternoon' | 'Evening',
+): 9 | 13 | 20 => {
+  switch (remindTime) {
+    case 'Morning':
+      return 9;
+    case 'Afternoon':
+      return 13;
+    case 'Evening':
+      return 20;
+  }
+};

--- a/src/utils/changeRemindTimeToString.ts
+++ b/src/utils/changeRemindTimeToString.ts
@@ -1,0 +1,12 @@
+export const changeRemindTimeToString = (
+  remindTime: 9 | 13 | 20,
+): 'Morning' | 'Afternoon' | 'Evening' => {
+  switch (remindTime) {
+    case 9:
+      return 'Morning';
+    case 13:
+      return 'Afternoon';
+    case 20:
+      return 'Evening';
+  }
+};

--- a/src/utils/currentMonth.ts
+++ b/src/utils/currentMonth.ts
@@ -1,0 +1,4 @@
+export const currentMonth = () => {
+  const currentDate = new Date();
+  return currentDate.getMonth() + 1;
+};


### PR DESCRIPTION
## 📌 이슈 번호

close #86

## 🚀 구현 내용
계획 작성, 상세, 수정 페이지에서 쓰이는 API들을 현재 mock으로 연결해 두었습니다.  아직 연결하지 못한 API들은 노철님, 혜수님이 훅 구현해주시면 바로 연결하겠습니다 !!

**작성 페이지**
- [x]  계획 작성 API

**상세 페이지**
- [ ]  계획 단건 조회  API ⇒ `노철`님이 API 구현 후 제가 **상세 페이지**에서 연결할 예정
- [x]  리마인드 정보 조회 API ⇒ ReadOnlyRemind 컴포넌트에서 정의
- [x] 계획 삭제 API  ⇒ 페이지에서 정의 
- [x] 리마인드 알림 toggle API  ⇒ ReadOnlyRemind 컴포넌트에서 정의
- [ ] 피드백 반영 API ⇒ `혜수`님이 API 구현 후 제가 ReadOnlyRemind 컴포넌트에서 연결 예정

**수정 페이지**
- [ ]  계획 단건 조회 API ⇒ `노철`님이 구현 후 제가 **수정 페이지**에서 연결할 예정
- [x]  리마인드 정보 조회 API ⇒ 페이지 level에서 연결
- [x] 계획 수정 API ⇒ 페이지 level에서 연결


<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
