### PR TITLE
[혜수] - 내 계획 페이지 추가 수정

### DIFF
--- a/src/app/(header)/home/_components/NewPlan/NewPlan.tsx
+++ b/src/app/(header)/home/_components/NewPlan/NewPlan.tsx
@@ -1,4 +1,5 @@
 import { Icon } from '@/components';
+import { checkIsSeason } from '@/utils/checkIsSeason';
 import classNames from 'classnames';
 import Link from 'next/link';
 import './index.scss';
@@ -7,10 +8,16 @@ export default function NewPlan() {
   return (
     <Link href={'/create'} className={classNames('new-plan__wrapper')}>
       <div className={classNames('new-plan__wrapper--icon')}>
-        <Icon name="CREATE_NEW_PLAN" size="9xl" color="gray-200" />
+        <Icon
+          name={checkIsSeason() ? 'CREATE_NEW_PLAN' : 'AJAJA'}
+          size="9xl"
+          color="gray-200"
+        />
       </div>
       <p className={classNames('color-origin-gray-200')}>
-        새로운 신년 계획을 생성해보세요!
+        {checkIsSeason()
+          ? '새로운 신년 계획을 생성해보세요!'
+          : '[작성 시즌 종료] 내년에 만나요!'}
       </p>
     </Link>
   );

--- a/src/app/(header)/home/page.tsx
+++ b/src/app/(header)/home/page.tsx
@@ -1,4 +1,5 @@
 // import { getMyPlans } from '@/hooks/apis/plans/useMyPlansQuery';
+import { checkThisYear } from '@/utils/checkThisYear';
 import classNames from 'classnames';
 // import NewPlan from './_components/NewPlan/NewPlan';
 // import Plan from './_components/Plan/Plan';
@@ -13,30 +14,30 @@ export default async function HomePage() {
   const myPlans = {
     success: true,
     data: [
-      {
-        year: 2023,
-        totalAchieveRate: 50,
-        getPlanList: [
-          {
-            title: '매일 운동하기',
-            isRemindable: true,
-            achieveRate: 90,
-            icon: 5,
-          },
-          {
-            title: '매일 코딩하기',
-            isRemindable: true,
-            achieveRate: 90,
-            icon: 8,
-          },
-          {
-            title: '매일 아침 9시에 일어나기',
-            isRemindable: false,
-            achieveRate: 20,
-            icon: 3,
-          },
-        ],
-      },
+      // {
+      //   year: 2023,
+      //   totalAchieveRate: 50,
+      //   getPlanList: [
+      //     {
+      //       title: '매일 운동하기',
+      //       isRemindable: true,
+      //       achieveRate: 90,
+      //       icon: 5,
+      //     },
+      //     {
+      //       title: '매일 코딩하기',
+      //       isRemindable: true,
+      //       achieveRate: 90,
+      //       icon: 8,
+      //     },
+      //     {
+      //       title: '매일 아침 9시에 일어나기',
+      //       isRemindable: false,
+      //       achieveRate: 20,
+      //       icon: 3,
+      //     },
+      //   ],
+      // },
       {
         year: 2022,
         totalAchieveRate: 80,
@@ -63,6 +64,13 @@ export default async function HomePage() {
       },
     ],
   };
+  if (!myPlans.data.length || myPlans.data[0].year !== checkThisYear()) {
+    myPlans.data.unshift({
+      year: checkThisYear(),
+      totalAchieveRate: 50,
+      getPlanList: [],
+    });
+  }
 
   return (
     <>

--- a/src/utils/checkThisYear.ts
+++ b/src/utils/checkThisYear.ts
@@ -1,0 +1,5 @@
+export const checkThisYear = () => {
+  const currentDate = new Date();
+  const currentYear = currentDate.getFullYear();
+  return currentYear;
+};


### PR DESCRIPTION
## 📌 이슈 번호

close #97 

## 🚀 구현 내용
- 현재 년도 확인 함수 추가
- 현재 년도 계획이 비어있을 때 빈 배열 추가 로직 추가
- 시즌, 비시즌 구분해 작성 컴포넌트 변경 완료 
## 📘 참고 사항
![image](https://github.com/New-Barams/this-year-ajaja-fe/assets/67812466/269fbcf0-624e-4668-8872-f454b4bf41ac)
![image](https://github.com/New-Barams/this-year-ajaja-fe/assets/67812466/5cf1dcd9-48be-46f3-8cbd-98d652e59acb)
![image](https://github.com/New-Barams/this-year-ajaja-fe/assets/67812466/155f4e76-90ac-4f23-9ff2-d4d8cbe30b25)

<!--## ❓ 궁금한 내용-->
