### PR TITLE
[민우] - 실제 API 연결 및 오류 해결 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^1.6.0",
         "classnames": "^2.3.2",
         "cookies-next": "^4.0.0",
+        "jwt-decode": "^4.0.0",
         "next": "14.0.0",
         "react": "^18",
         "react-circular-progressbar": "^2.1.0",
@@ -3650,6 +3651,14 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "axios": "^1.6.0",
         "classnames": "^2.3.2",
         "cookies-next": "^4.0.0",
-        "jwt-decode": "^4.0.0",
         "next": "14.0.0",
         "react": "^18",
         "react-circular-progressbar": "^2.1.0",
@@ -3651,14 +3650,6 @@
       },
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/jwt-decode": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
-      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "axios": "^1.6.0",
     "classnames": "^2.3.2",
     "cookies-next": "^4.0.0",
-    "jwt-decode": "^4.0.0",
     "next": "14.0.0",
     "react": "^18",
     "react-circular-progressbar": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "axios": "^1.6.0",
     "classnames": "^2.3.2",
     "cookies-next": "^4.0.0",
+    "jwt-decode": "^4.0.0",
     "next": "14.0.0",
     "react": "^18",
     "react-circular-progressbar": "^2.1.0",

--- a/src/apis/client/deletePlan.ts
+++ b/src/apis/client/deletePlan.ts
@@ -1,9 +1,8 @@
 import { DOMAIN } from '@/constants/api';
-import { currentMonth } from '@/utils/currentMonth';
 import { axiosInstanceClient } from '../axiosInstanceClient';
 
 export const deletePlan = (planId: number) => {
   return axiosInstanceClient.delete(DOMAIN.DELETE_PLANS(planId), {
-    headers: { Month: currentMonth() },
+    headers: { Month: 1 }, // TODO: Month: currentMonth()로 바꿔줘야 함
   });
 };

--- a/src/apis/client/editPlan.ts
+++ b/src/apis/client/editPlan.ts
@@ -1,19 +1,13 @@
 import { DOMAIN } from '@/constants/api';
-import { EditPlanData } from '@/types/apis/plan/EditPlan';
-import { currentMonth } from '@/utils/currentMonth';
+import { editPlanProps } from '@/types/apis/plan/EditPlan';
 import { axiosInstanceClient } from '../axiosInstanceClient';
-
-interface editPlanProps {
-  planId: number;
-  planData: EditPlanData;
-}
 
 export const editPlan = async ({ planId, planData }: editPlanProps) => {
   const { data } = await axiosInstanceClient.put(
     DOMAIN.PUT_PLANS(planId),
-    { data: planData },
+    { ...planData },
     {
-      headers: { Month: currentMonth() },
+      headers: { Month: 1 }, // TODO: Month: currentMonth()로 바꿔줘야 함
     },
   );
   return data;

--- a/src/apis/client/getRemindAfterSeason.ts
+++ b/src/apis/client/getRemindAfterSeason.ts
@@ -6,6 +6,5 @@ export const getRemindAfterSeason = async (
   planId: number,
 ): Promise<GetRemindResponse> => {
   const { data } = await axiosInstanceClient.get(DOMAIN.GET_REMINDS(planId));
-
   return data;
 };

--- a/src/apis/client/getRemindAfterSeason.ts
+++ b/src/apis/client/getRemindAfterSeason.ts
@@ -1,10 +1,10 @@
 import { DOMAIN } from '@/constants/api';
-import { RemindData } from '@/types/components/Remind';
+import { GetRemindResponse } from '@/types/apis/remind/getRemind';
 import { axiosInstanceClient } from '../axiosInstanceClient';
 
 export const getRemindAfterSeason = async (
   planId: number,
-): Promise<RemindData> => {
+): Promise<GetRemindResponse> => {
   const { data } = await axiosInstanceClient.get(DOMAIN.GET_REMINDS(planId));
 
   return data;

--- a/src/apis/client/getRemindSeason.ts
+++ b/src/apis/client/getRemindSeason.ts
@@ -5,13 +5,9 @@ import { axiosInstanceClient } from '../axiosInstanceClient';
 export const getRemindSeason = async (
   planId: number,
 ): Promise<GetRemindResponse> => {
-  console.log('리마인드 정보조회 시즌 API 호출');
   const { data } = await axiosInstanceClient.get(
     DOMAIN.GET_REMINDS_MODIFY(planId),
   );
-
-  console.log(`받아온 data`);
-  console.log(data);
 
   return data;
 };

--- a/src/apis/client/getRemindSeason.ts
+++ b/src/apis/client/getRemindSeason.ts
@@ -1,11 +1,17 @@
 import { DOMAIN } from '@/constants/api';
-import { RemindData } from '@/types/components/Remind';
+import { GetRemindResponse } from '@/types/apis/remind/getRemind';
 import { axiosInstanceClient } from '../axiosInstanceClient';
 
-export const getRemindSeason = async (planId: number): Promise<RemindData> => {
+export const getRemindSeason = async (
+  planId: number,
+): Promise<GetRemindResponse> => {
+  console.log('리마인드 정보조회 시즌 API 호출');
   const { data } = await axiosInstanceClient.get(
     DOMAIN.GET_REMINDS_MODIFY(planId),
   );
+
+  console.log(`받아온 data`);
+  console.log(data);
 
   return data;
 };

--- a/src/apis/client/postNewPlan.ts
+++ b/src/apis/client/postNewPlan.ts
@@ -3,8 +3,14 @@ import { PostNewPlanRequestBody } from '@/types/apis/plan/PostNewPlan';
 import { axiosInstanceClient } from '../axiosInstanceClient';
 
 export const postNewPlan = async (body: PostNewPlanRequestBody) => {
-  const { data } = await axiosInstanceClient.post(DOMAIN.POST_PLANS, {
-    data: body,
-  });
+  const { data } = await axiosInstanceClient.post(
+    DOMAIN.POST_PLANS,
+    {
+      ...body,
+    },
+    {
+      headers: { Month: 1 }, // TODO: currentMonth로 바꿔줘야 함
+    },
+  );
   return data;
 };

--- a/src/apis/client/postNewPlan.ts
+++ b/src/apis/client/postNewPlan.ts
@@ -9,7 +9,7 @@ export const postNewPlan = async (body: PostNewPlanRequestBody) => {
       ...body,
     },
     {
-      headers: { Month: 1 }, // TODO: currentMonth로 바꿔줘야 함
+      headers: { Month: 1 }, // TODO: Month: currentMonth()로 바꿔줘야 함
     },
   );
   return data;

--- a/src/app/(header)/create/page.tsx
+++ b/src/app/(header)/create/page.tsx
@@ -119,6 +119,7 @@ export default function CreatePage() {
         return messageItem.message;
       }),
     };
+
     createNewPlanAPI(data);
   };
 

--- a/src/app/(header)/edit/[planId]/page.tsx
+++ b/src/app/(header)/edit/[planId]/page.tsx
@@ -76,8 +76,8 @@ export default function EditPage({ params }: { params: { planId: string } }) {
     });
   };
 
-  const [remindMessageList, setRemindMessageList] = useState<RemindItemType[]>(
-    remindData.remindMessageList.map((remindItem) => {
+  const [remindMessageList, setRemindMessageList] = useState<RemindItemType[]>([
+    ...remindData.sentRemindResponses.map((remindItem) => {
       return {
         date: {
           month: remindItem.remindMonth,
@@ -86,7 +86,16 @@ export default function EditPage({ params }: { params: { planId: string } }) {
         message: remindItem.remindMessage,
       };
     }),
-  );
+    ...remindData.futureRemindResponses.map((remindItem) => {
+      return {
+        date: {
+          month: remindItem.remindMonth,
+          day: remindItem.remindDate,
+        },
+        message: remindItem.remindMessage,
+      };
+    }),
+  ]);
 
   const handleChangeRemindMessage = (
     month: number,

--- a/src/app/(header)/edit/[planId]/page.tsx
+++ b/src/app/(header)/edit/[planId]/page.tsx
@@ -20,7 +20,7 @@ import './index.scss';
 export default function EditPage({ params }: { params: { planId: string } }) {
   const { planId } = params;
 
-  // 1-1. 계획 단건 조회 API를 통해 계획 data 받아오기
+  // 1-1. TODO: 계획 단건 조회 API를 통해 계획 data 받아오기
   const planData: PlanData = {
     id: 123,
     userId: 123,

--- a/src/app/(header)/plans/[planId]/page.tsx
+++ b/src/app/(header)/plans/[planId]/page.tsx
@@ -21,7 +21,7 @@ export default function PlanIdPage({ params }: { params: { planId: string } }) {
 
   // TODO: 1. 계획 단건 조회 API를 통해 받아오는 걸로 변경
   const planData: PlanData = {
-    id: 2342342,
+    id: 7,
     userId: 2342342,
     nickname: '유저 닉네임',
     title: '계획 내용 테스트 ',
@@ -30,7 +30,7 @@ export default function PlanIdPage({ params }: { params: { planId: string } }) {
     tags: ['태그1', '태그2', '태그3', '태그4', '태그5'],
     ajajas: 32343,
     isAjajaOn: true,
-    isCanAjaja: false,
+    isCanAjaja: true,
     createdAt: '2023-06-15',
   };
 
@@ -45,7 +45,7 @@ export default function PlanIdPage({ params }: { params: { planId: string } }) {
   const handleModalClickYes = () => {
     setIsDeletePlanModalOpen(false);
     deletePlanAPI(parseInt(planId, 10));
-    router.back(); // 계획 삭제 했으니 상세 페이지 이전으로 1단계 이동
+    router.replace('/home'); // TODO: 계획 삭제 했으니 상세 페이지 이전으로 1단계 이동하려고 back으로 했는데 일단 잘 안되서 /home으로 변경
   };
 
   const handleModalClickNo = () => {
@@ -58,11 +58,11 @@ export default function PlanIdPage({ params }: { params: { planId: string } }) {
 
       {isMyPlan && (
         <div className="plans-page__remind">
-          <ReadOnlyRemind planId={planId} />{' '}
+          <ReadOnlyRemind planId={planId} />
         </div>
       )}
 
-      {isMyPlan && !isSeason && (
+      {isMyPlan && isSeason && (
         <div className={classNames('plans-page__button__container')}>
           <Link href={`/edit/${planId}`}>
             <Button

--- a/src/components/Remind/ReadOnlyRemind/ReadOnlyRemind.tsx
+++ b/src/components/Remind/ReadOnlyRemind/ReadOnlyRemind.tsx
@@ -90,9 +90,9 @@ export default function ReadOnlyRemind({ planId }: ReadOnlyRemindProps) {
         </span>
       </div>
 
-      {remindData.remindMessageList.length !== 0 && (
-        <ul className={classNames('readonly-remind__message__list')}>
-          {remindData.remindMessageList.map((item, index) => {
+      <ul className={classNames('readonly-remind__message__list')}>
+        {remindData.sentRemindResponses.length !== 0 &&
+          remindData.sentRemindResponses.map((item, index) => {
             return (
               <ReadOnlyRemindItem
                 key={index}
@@ -101,8 +101,17 @@ export default function ReadOnlyRemind({ planId }: ReadOnlyRemindProps) {
               />
             );
           })}
-        </ul>
-      )}
+        {remindData.futureRemindResponses.length !== 0 &&
+          remindData.futureRemindResponses.map((item, index) => {
+            return (
+              <ReadOnlyRemindItem
+                key={index}
+                data={item}
+                classNameList={['readonly-remind__message__item']}
+              />
+            );
+          })}
+      </ul>
     </div>
   );
 }

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -23,22 +23,22 @@ export const DOMAIN = {
   GET_PLANS_REMINDS_MESSAGES: (userId: number) =>
     `/mock/plans/${userId}/reminds/messages`,
   GET_PLANS: (planId: number) => `/mock/plans/${planId}`,
-  PUT_PLANS: (planId: number) => `/mock/plans/${planId}`,
-  DELETE_PLANS: (planId: number) => `/mock/plans/${planId}`,
+  PUT_PLANS: (planId: number) => `/plans/${planId}`,
+  DELETE_PLANS: (planId: number) => `/plans/${planId}`,
   PUT_PLANS_SWITCH_REMINDABLE: (planId: number) =>
-    `/mock/plans/${planId}/remindable`,
-  PUT_PLANS_SWITCH_PUBLIC: (planId: number) => `/mock/plans/${planId}/public`,
-  PUT_PLANS_SWITCH_AJAJA: (planId: number) => `/mock/plans/${planId}/ajaja`,
+    `/plans/${planId}/remindable`,
+  PUT_PLANS_SWITCH_PUBLIC: (planId: number) => `/plans/${planId}/public`,
+  PUT_PLANS_SWITCH_AJAJA: (planId: number) => `/plans/${planId}/ajaja`,
   GET_PLANS_ALL: '/mock/plans',
-  POST_PLANS: '/plans', // 계획 생성 API
+  POST_PLANS: '/plans',
   GET_PLANS_FEEDBAKS: (planId: number) => `/plans/${planId}/feedbacks`,
   GET_PLANS_MAIN: (userId: number) => `/mock/plans/main/${userId}`,
 
-  GET_REMINDS: (planId: number) => `/mock/reminds/${planId}`,
-  GET_REMINDS_MODIFY: (planId: number) => `/mock/reminds/modify/${planId}`,
+  GET_REMINDS: (planId: number) => `/reminds/${planId}`,
+  GET_REMINDS_MODIFY: (planId: number) => `/reminds/modify/${planId}`,
 };
 
-//실제 API -> swagger 순서입니다.
+// 실제 API -> swagger 순서입니다.
 // PUT_USERS_RECEIVE: '/users/receive',
 // POST_USERS_VERIFY: '/users/verify',
 // POST_USERS_SEND_VERIFICATION: '/users/send-verification',

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -30,7 +30,7 @@ export const DOMAIN = {
   PUT_PLANS_SWITCH_PUBLIC: (planId: number) => `/mock/plans/${planId}/public`,
   PUT_PLANS_SWITCH_AJAJA: (planId: number) => `/mock/plans/${planId}/ajaja`,
   GET_PLANS_ALL: '/mock/plans',
-  POST_PLANS: '/mock/plans',
+  POST_PLANS: '/plans', // 계획 생성 API
   GET_PLANS_FEEDBAKS: (planId: number) => `/plans/${planId}/feedbacks`,
   GET_PLANS_MAIN: (userId: number) => `/mock/plans/main/${userId}`,
 

--- a/src/hooks/apis/useGetRemindQuery.ts
+++ b/src/hooks/apis/useGetRemindQuery.ts
@@ -10,5 +10,5 @@ export const useGetRemindQuery = (planId: number, isSeason: boolean) => {
     },
   });
 
-  return { remindData: data! };
+  return { remindData: data!.data };
 };

--- a/src/hooks/apis/useToggleAjajaNotificationMutation.ts
+++ b/src/hooks/apis/useToggleAjajaNotificationMutation.ts
@@ -6,5 +6,3 @@ export const useToggleAjajaNotificationMutation = () => {
     mutationFn: toggleAjajaNotification,
   });
 };
-
-// onSuccess 옵션에 계획 조회하는 useQuery의 key를 invalidate 해서 refetch 하도록 ?

--- a/src/types/apis/plan/EditPlan.ts
+++ b/src/types/apis/plan/EditPlan.ts
@@ -4,7 +4,7 @@ export interface EditPlanData {
   remindTotalPeriod: number;
   remindTerm: number;
   remindDate: number;
-  remindTime: 'Morning' | 'Afternoon' | 'Evening';
+  remindTime: 'MORNING' | 'AFTERNOON' | 'EVENING';
   isPublic: boolean;
   canRemind: boolean;
   canAjaja: boolean;

--- a/src/types/apis/plan/EditPlan.ts
+++ b/src/types/apis/plan/EditPlan.ts
@@ -11,3 +11,8 @@ export interface EditPlanData {
   tags: string[];
   messages: string[];
 }
+
+export interface editPlanProps {
+  planId: number;
+  planData: EditPlanData;
+}

--- a/src/types/apis/plan/PostNewPlan.ts
+++ b/src/types/apis/plan/PostNewPlan.ts
@@ -4,7 +4,7 @@ export interface PostNewPlanRequestBody {
   remindTotalPeriod: number;
   remindTerm: number;
   remindDate: number;
-  remindTime: 'Morning' | 'Afternoon' | 'Evening';
+  remindTime: 'MORNING' | 'AFTERNOON' | 'EVENING';
   isPublic: boolean;
   tags: string[];
   messages: string[];

--- a/src/types/apis/remind/getRemind.ts
+++ b/src/types/apis/remind/getRemind.ts
@@ -1,0 +1,6 @@
+import { RemindData } from '@/types/components/Remind';
+
+export interface GetRemindResponse {
+  success: boolean;
+  data: RemindData;
+}

--- a/src/types/components/Remind.ts
+++ b/src/types/components/Remind.ts
@@ -33,7 +33,7 @@ export interface ReadOnlyRemindItemData {
 
 export interface RemindData {
   isRemindable: boolean;
-  remindTime: 'Morning' | 'Afternoon' | 'Evening';
+  remindTime: 'MORNING' | 'AFTERNOON' | 'EVENING';
   remindDate: number;
   remindTerm: number;
   remindTotalPeriod: number;

--- a/src/types/components/Remind.ts
+++ b/src/types/components/Remind.ts
@@ -37,5 +37,6 @@ export interface RemindData {
   remindDate: number;
   remindTerm: number;
   remindTotalPeriod: number;
-  remindMessageList: ReadOnlyRemindItemData[];
+  sentRemindResponses: ReadOnlyRemindItemData[] | [];
+  futureRemindResponses: ReadOnlyRemindItemData[] | [];
 }

--- a/src/utils/changeRemindTimeToNumber.ts
+++ b/src/utils/changeRemindTimeToNumber.ts
@@ -1,12 +1,12 @@
 export const changeRemindTimeToNumber = (
-  remindTime: 'Morning' | 'Afternoon' | 'Evening',
+  remindTime: 'MORNING' | 'AFTERNOON' | 'EVENING',
 ): 9 | 13 | 20 => {
   switch (remindTime) {
-    case 'Morning':
+    case 'MORNING':
       return 9;
-    case 'Afternoon':
+    case 'AFTERNOON':
       return 13;
-    case 'Evening':
+    case 'EVENING':
       return 20;
   }
 };

--- a/src/utils/changeRemindTimeToString.ts
+++ b/src/utils/changeRemindTimeToString.ts
@@ -1,12 +1,12 @@
 export const changeRemindTimeToString = (
   remindTime: 9 | 13 | 20,
-): 'Morning' | 'Afternoon' | 'Evening' => {
+): 'MORNING' | 'AFTERNOON' | 'EVENING' => {
   switch (remindTime) {
     case 9:
-      return 'Morning';
+      return 'MORNING';
     case 13:
-      return 'Afternoon';
+      return 'AFTERNOON';
     case 20:
-      return 'Evening';
+      return 'EVENING';
   }
 };

--- a/src/utils/checkIsSeason.ts
+++ b/src/utils/checkIsSeason.ts
@@ -1,5 +1,5 @@
 export const checkIsSeason = () => {
   const currentDate = new Date();
   const currentMonth = currentDate.getMonth();
-  return currentMonth === 0;
+  return currentMonth !== 0;
 };

--- a/src/utils/getUserIdFromJWT.ts
+++ b/src/utils/getUserIdFromJWT.ts
@@ -1,0 +1,11 @@
+type AjajaJWTPayload = {
+  ajajajwt: number;
+  exp: number;
+};
+
+export const getUserIdFromJWT = (token: string) => {
+  const base64Payload = token.split('.')[1]; //value 0 -> header, 1 -> payload, 2 -> VERIFY SIGNATURE
+  const payload = Buffer.from(base64Payload, 'base64');
+  const result = JSON.parse(payload.toString()) as AjajaJWTPayload;
+  return result.ajajajwt;
+};


### PR DESCRIPTION
## 📌 이슈 번호

close #119

## 🚀 구현 내용
### 실제 API 정상 동작 확인 
현재 작성, 수정,  상세페이지에서 사용되는 
- [x]  계획 작성 API
- [x]  리마인드 조회 API - 시즌
- [x]  리마인드 조회 API - 비시즌 
- [x]  계획 삭제 API
- [x]  계획 수정 API
- [x]  리마인드 알림 toggle API - 디바운스까지
- [x]  공개여부 toggle API - 디바운스까지
- [x]  알림메시지 toggle API - 디바운스까지

모두 실제 API로 잘 동작하는 것 확인했습니다 !  노철님 혜수님이 계획 단건 조회 API와 피드백 반영 API가 구현해주면 => 각 페이지에 제가 연결하면 될 것 같습니다 ! 위의 API가 동작은 하지만, 아직까지는 로딩 처리, 에러 처리, API 호출로 발생하는 자잘한 이슈들이 있는 상태라 차차 해결하겠습니다,,,, ㅎㅎㅎ

### JWT 토큰에서 userId 반환하는 유틸함수 구현
참고 : 986317ccbbd66d5292b03a59861f0bf92c953e6e
이를 이용해 쿠키의 userId vs 특정 계획의 userId 비교해 내 계획인지 판단하는 훅도 구현 예정입니다 !!


<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
