### PR TITLE
[혜수] - 내 계획 페이지 계획 클릭시 올바른 planId 경로로 들어가도록 추가

### DIFF
--- a/src/app/(header)/home/_components/MyPlan.tsx
+++ b/src/app/(header)/home/_components/MyPlan.tsx
@@ -58,6 +58,7 @@ export default function MyPlan({ myPlans }: MyPlanProps) {
             <Plan
               key={index}
               title={plan.title}
+              planId={plan.planId}
               achieveRate={plan.achieveRate}
               icon={plan.icon}
             />

--- a/src/app/(header)/home/_components/Plan/Plan.tsx
+++ b/src/app/(header)/home/_components/Plan/Plan.tsx
@@ -7,15 +7,16 @@ import './index.scss';
 
 type PlanProps = {
   title: string;
+  planId: number;
   achieveRate: number;
   icon: number;
 };
 
-export default function Plan({ title, achieveRate, icon }: PlanProps) {
+export default function Plan({ title, planId, achieveRate, icon }: PlanProps) {
   const achieveColor: Color = achieveColorChange(achieveRate);
 
   return (
-    <Link href={'/plans/1'} className={classNames('plan__wrapper')}>
+    <Link href={`/plans/${planId}`} className={classNames('plan__wrapper')}>
       <div className={classNames('plan__wrapper--icon')}>
         <Icon name={planIcons[icon]} size="9xl" color="orange-300" />
       </div>


### PR DESCRIPTION
## 📌 이슈 번호

close #124

## 🚀 구현 내용
- 내 계획 페이지 계획 클릭시 올바른 planId 경로로 들어가도록 추가
<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
