### PR TITLE
[혜수] - 내 계획 페이지 API server -> client로 변경

### DIFF
--- a/src/apis/client/getMyPlans.ts
+++ b/src/apis/client/getMyPlans.ts
@@ -1,9 +1,9 @@
 import { DOMAIN } from '@/constants/api';
 import { GetMyPlansResponse } from '@/types/apis/plan/GetMyPlans';
-import { axiosInstanceServer } from '@apis/axiosInstanceServer';
+import { axiosInstanceClient } from '../axiosInstanceClient';
 
 export const getMyPlans = async () => {
-  const { data } = await axiosInstanceServer.get<GetMyPlansResponse>(
+  const { data } = await axiosInstanceClient.get<GetMyPlansResponse>(
     DOMAIN.GET_PLANS_MAIN,
   );
   return data;

--- a/src/app/(header)/home/page.tsx
+++ b/src/app/(header)/home/page.tsx
@@ -1,15 +1,13 @@
-import { getMyPlans } from '@/apis/server/getMyPlans';
+'use client';
+
+import { useGetMyPlansQuery } from '@/hooks/apis/plans/useGetMyPlansQuery';
 import { checkThisYear } from '@/utils/checkThisYear';
 import classNames from 'classnames';
-// import NewPlan from './_components/NewPlan/NewPlan';
-// import Plan from './_components/Plan/Plan';
-// import ProgressBar from './_components/ProgressBar/ProgressBar';
 import MyPlan from './_components/MyPlan';
 import './_components/index.scss';
 
-export default async function HomePage() {
-  const myPlans = await getMyPlans();
-  // console.log(data.getPlanList);
+export default function HomePage() {
+  const { myPlans } = useGetMyPlansQuery();
 
   // const myPlans = {
   //   success: true,

--- a/src/hooks/apis/plans/useGetMyPlansQuery.ts
+++ b/src/hooks/apis/plans/useGetMyPlansQuery.ts
@@ -1,0 +1,13 @@
+'use client';
+
+import { getMyPlans } from '@/apis/client/getMyPlans';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+export const useGetMyPlansQuery = () => {
+  const { data } = useSuspenseQuery({
+    queryKey: ['getMyPlans'],
+    queryFn: getMyPlans,
+    staleTime: 10000,
+  });
+  return { myPlans: data! };
+};


### PR DESCRIPTION
## 📌 이슈 번호

close #127 

## 🚀 구현 내용
- 내 계획 페이지 api 클라이언트 컴포넌트로 변경
- react query 적용

<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
