### PR TITLE
[노철] - 로그인 방식 변경

### DIFF
--- a/src/apis/client/getTokenWithCode.ts
+++ b/src/apis/client/getTokenWithCode.ts
@@ -1,11 +1,18 @@
 import { DOMAIN } from '@/constants/api';
-import { getTokenWithCodeResponse } from '@/types/apis/login/getTokenWithCoin';
+import {
+  getTokenWithCodeRequestBody,
+  getTokenWithCodeResponse,
+} from '@/types/apis/login/getTokenWithCoin';
 import { axiosInstanceClient } from '../axiosInstanceClient';
 
 export const getTokenWithCode = async (code: string) => {
+  const requestBody: getTokenWithCodeRequestBody = {
+    authorizationCode: code,
+    redirectUrl: `${process.env.NEXT_PUBLIC_REDIRECT_URL}`,
+  };
   const { data } = await axiosInstanceClient.post<getTokenWithCodeResponse>(
-    DOMAIN.POST_LOGIN(code),
-    null,
+    DOMAIN.POST_LOGIN,
+    requestBody,
     {
       authorization: false,
     },

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -15,7 +15,7 @@ export const DOMAIN = {
   GET_FEEDBACKS_EACH: (planId: number) => `/mock/${planId}/feedbacks`,
 
   POST_REISSUE: '/mock/reissue',
-  POST_LOGIN: (code: string) => `/mock/login?code=${code}`,
+  POST_LOGIN: `/mock/login`,
 
   GET_PLANS_REMINDS: (planId: number) => `/mock/plans/${planId}/reminds`,
   PUT_PLANS_REMINDS: (planId: number) => `/mock/plans/${planId}/reminds`,

--- a/src/types/apis/login/getTokenWithCoin.ts
+++ b/src/types/apis/login/getTokenWithCoin.ts
@@ -4,3 +4,8 @@ export interface getTokenWithCodeResponse {
   success: boolean;
   data: auth;
 }
+
+export interface getTokenWithCodeRequestBody {
+  authorizationCode: string;
+  redirectUrl: string;
+}


### PR DESCRIPTION
## 📌 이슈 번호

close #133 

## 🚀 구현 내용

로그인api 방식이 변경됐습니다. 
 기존=> query로  인가코드 전달
 변경=> requestBody로 인가코드, 리다이렉트 주소 전달

# 로컬에서 사용하실 때 redirect url 환경 변수가 꼭 있어야 합니다. (노션 환경변수 참조)

<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
