### PR TITLE
[민우] - 상세 페이지 초기 진입 로직 추가 및 임시 로딩 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react": "^18",
         "react-circular-progressbar": "^2.1.0",
         "react-dom": "^18",
+        "react-spinners": "^0.13.8",
         "recoil": "^0.7.7"
       },
       "devDependencies": {
@@ -4530,6 +4531,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/react-spinners": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.13.8.tgz",
+      "integrity": "sha512-3e+k56lUkPj0vb5NDXPVFAOkPC//XyhKPJjvcGjyMNPWsBKpplfeyialP74G7H7+It7KzhtET+MvGqbKgAqpZA==",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/readdirp": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "^18",
     "react-circular-progressbar": "^2.1.0",
     "react-dom": "^18",
+    "react-spinners": "^0.13.8",
     "recoil": "^0.7.7"
   },
   "devDependencies": {

--- a/src/app/(header)/edit/[planId]/page.tsx
+++ b/src/app/(header)/edit/[planId]/page.tsx
@@ -4,9 +4,9 @@ import { Button, Modal, WritableRemind } from '@/components';
 import ModalExit from '@/components/Modal/ModalExit';
 import WritablePlan from '@/components/WritablePlan/WritablePlan';
 import { useEditPlanMutation } from '@/hooks/apis/useEditPlanMutation';
+import { useGetPlanQuery } from '@/hooks/apis/useGetPlanQuery';
 import { useGetRemindQuery } from '@/hooks/apis/useGetRemindQuery';
 import { EditPlanData } from '@/types/apis/plan/EditPlan';
-import { PlanData } from '@/types/apis/plan/GetPlan';
 import { RemindItemType, RemindOptionType } from '@/types/components/Remind';
 import { changeRemindTimeToNumber } from '@/utils/changeRemindTimeToNumber';
 import { changeRemindTimeToString } from '@/utils/changeRemindTimeToString';
@@ -21,20 +21,7 @@ export default function EditPage({ params }: { params: { planId: string } }) {
   const { planId } = params;
 
   // 1-1. TODO: 계획 단건 조회 API를 통해 계획 data 받아오기
-  const planData: PlanData = {
-    id: 123,
-    userId: 123,
-    nickname: 'nononoere',
-    title: '계획 제목 테스트',
-    description: '계획 설명 테스트',
-    isPublic: true,
-    canRemind: true,
-    canAjaja: true,
-    ajajas: 100,
-    isPressAjaja: true,
-    tags: ['태그1', '태그2', '태그3', '태그4', '태그5'],
-    createdAt: '2023-06-15',
-  };
+  const { plan: planData } = useGetPlanQuery(Number(planId));
 
   // 1-2. 리마인드 정보 조회 API 호출해서 받아온 data 받아오기
   const { remindData } = useGetRemindQuery(

--- a/src/app/(header)/plans/[planId]/page.tsx
+++ b/src/app/(header)/plans/[planId]/page.tsx
@@ -19,8 +19,8 @@ import './index.scss';
 
 export default function PlanIdPage({ params }: { params: { planId: string } }) {
   const { planId } = params;
-  const isSeason = checkIsSeason();
   const router = useRouter();
+  const isSeason = checkIsSeason();
 
   const { plan } = useGetPlanQuery(Number(planId));
   const isMyPlan = checkIsMyPlan(plan.userId);

--- a/src/app/(header)/plans/[planId]/page.tsx
+++ b/src/app/(header)/plans/[planId]/page.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components';
 import { useDeletePlanMutation } from '@/hooks/apis/useDeletePlanMutation';
 import { useGetPlanQuery } from '@/hooks/apis/useGetPlanQuery';
+import { checkIsMyPlan } from '@/utils/checkIsMyPlan';
 import { checkIsSeason } from '@/utils/checkIsSeason';
 import classNames from 'classnames';
 import Link from 'next/link';
@@ -17,27 +18,12 @@ import { useState } from 'react';
 import './index.scss';
 
 export default function PlanIdPage({ params }: { params: { planId: string } }) {
+  const { planId } = params;
+  const isSeason = checkIsSeason();
   const router = useRouter();
 
-  // TODO: 1. 계획 단건 조회 API를 통해 받아오는 걸로 변경
-  // const planData: PlanData = {
-  //   id: 7,
-  //   userId: 2342342,
-  //   nickname: '유저 닉네임',
-  //   title: '계획 내용 테스트 ',
-  //   description: '계획 설명',
-  //   isPublic: true,
-  //   tags: ['태그1', '태그2', '태그3', '태그4', '태그5'],
-  //   ajajas: 32343,
-  //   isAjajaOn: true,
-  //   isCanAjaja: true,
-  //   createdAt: '2023-06-15',
-  // };
-
-  const { planId } = params;
   const { plan } = useGetPlanQuery(Number(planId));
-  const isSeason = checkIsSeason();
-  const isMyPlan = true; // TODO: 2. 쿠키에 있는 토큰을 decode해서 userId를 받아온 후, 1번 planData의 userId와 비교해야 함
+  const isMyPlan = checkIsMyPlan(plan.userId);
 
   const [isDeletePlanModalOpen, setIsDeletePlanModalOpen] = useState(false);
 

--- a/src/app/loading.scss
+++ b/src/app/loading.scss
@@ -1,0 +1,6 @@
+.loading__wrapper {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <h1 style={{ margin: '200px' }}>로딩 중입니다 </h1>;
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,3 +1,11 @@
+import { COLOR } from '@/constants';
+import { FadeLoader } from 'react-spinners';
+import './loading.scss';
+
 export default function Loading() {
-  return <h1 style={{ margin: '200px' }}>로딩 중입니다 </h1>;
+  return (
+    <h1 className="loading__wrapper">
+      <FadeLoader color={COLOR.PRIMARY} speedMultiplier={1.3} />
+    </h1>
+  );
 }

--- a/src/components/RemindItem/ReadOnlyRemindItem/ReadOnlyRemindItem.tsx
+++ b/src/components/RemindItem/ReadOnlyRemindItem/ReadOnlyRemindItem.tsx
@@ -3,6 +3,7 @@
 import ModalEvaluate from '@/app/(header)/plans/[planId]/_components/ModalEvaluate/ModalEvaluate';
 import { Icon, Modal, RemindInput } from '@/components';
 import CircleProgressBar from '@/components/CircleProgressBar/CircleProgressBar';
+import { usePostFeedbackMutation } from '@/hooks/apis/feedback/usePostFeedbackMutation';
 import { ReadOnlyRemindItemData } from '@/types/components/Remind';
 import { checkIsSeason } from '@/utils/checkIsSeason';
 import classNames from 'classnames';
@@ -19,6 +20,8 @@ export default function ReadOnlyRemindItem({
   classNameList = [],
 }: ReadOnlyRemindItemProps) {
   const isSeason = checkIsSeason();
+
+  const { mutate: postFeedbackAPI } = usePostFeedbackMutation();
 
   const {
     remindMonth,
@@ -52,22 +55,20 @@ export default function ReadOnlyRemindItem({
   ) => {
     if (!isExpired && !isFeedback) {
       setIsFeedBackModalOpened(true);
-      console.log(`${feedbackId}에 대한 피드백 평가 모달 띄우기`);
     }
     event.stopPropagation(); // 상위 요소 item-header에 대한 onClick handler인 item 토글시키는 동작 안 되도록
   };
 
   const handleClickModalFinish = (rate: number) => {
     console.log(
-      `${feedbackId}에 대한 피드백 평가 ${rate}$로 평가 완료 피드백 수행 API 호출`,
+      `${feedbackId}번 피드백에 대한 피드백 ${rate}%로 평가 완료 피드백 수행 API 호출`,
     );
+    postFeedbackAPI({ feedbackId, body: { rate: rate } });
     setIsFeedBackModalOpened(false);
-    console.log('피드백 모달 닫기');
   };
 
   const handleClickModalExit = () => {
     setIsFeedBackModalOpened(false);
-    console.log('피드백 모달 닫기');
   };
 
   return (

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -23,7 +23,7 @@ export const DOMAIN = {
   POST_PLANS_REMINDS: (planId: number) => `/mock/plans/${planId}/reminds`,
   GET_PLANS_REMINDS_MESSAGES: (userId: number) =>
     `/mock/plans/${userId}/reminds/messages`,
-  GET_PLANS: (planId: number) => `/mock/plans/${planId}`,
+  GET_PLANS: (planId: number) => `/plans/${planId}`,
   PUT_PLANS: (planId: number) => `/plans/${planId}`,
   DELETE_PLANS: (planId: number) => `/plans/${planId}`,
   PUT_PLANS_SWITCH_REMINDABLE: (planId: number) =>

--- a/src/hooks/apis/useGetPlanQuery.ts
+++ b/src/hooks/apis/useGetPlanQuery.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 export const useGetPlanQuery = (id: number) => {
   const { data, isFetching, isError } = useQuery({
-    queryKey: ['plan'],
+    queryKey: ['plan', id],
     queryFn: () => getPlan(id),
   });
   return { plan: data!.data, isFetching, isError };

--- a/src/utils/checkIsMyPlan.ts
+++ b/src/utils/checkIsMyPlan.ts
@@ -1,0 +1,20 @@
+import { getCookie } from 'cookies-next';
+import { getUserIdFromJWT } from './getUserIdFromJWT';
+
+interface Auth {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export const checkIsMyPlan = (planUserId: number) => {
+  const auth = getCookie('auth');
+
+  if (auth !== undefined) {
+    const authObject = JSON.parse(auth) as Auth; // 쿠키에 있는 auth의 값이 있으면 Auth 타입일 것임
+    const currentUserId = getUserIdFromJWT(authObject.accessToken);
+
+    return planUserId === currentUserId;
+  }
+
+  return false;
+};

--- a/src/utils/checkIsSeason.ts
+++ b/src/utils/checkIsSeason.ts
@@ -1,5 +1,5 @@
 export const checkIsSeason = () => {
   const currentDate = new Date();
   const currentMonth = currentDate.getMonth();
-  return currentMonth !== 0;
+  return currentMonth !== 0; // TODO: 일단 현재는 무조건 시즌으로 동작하도록
 };


### PR DESCRIPTION
## 📌 이슈 번호

#122 

## 🚀 구현 내용
- [x] 피드백 반영 API 연결 6fb3424169800fa1af591db4948f31110fcc094d
- [x] 상세 페이지 진입 시, checkIsMyPlan 유틸 함수 이용해 내 계획인지 판단 5f3964962edccca4c7d7e98e4a0f53a7eb604539
- [x] 각 페이지에서 사용하는 임시 로딩 페이지 구현 26d8d7b89e81686e2d18fcbc5c4eb1d6dda8a204
- [x] 수정 페이지 계획 단건 조회 API 연결 04236a863d46d06517ce4363aae5d2f785274a3c

<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
