### PR TITLE
[혜수] - 내 계획 페이지 이메일 인증 여부 추가 

### DIFF
--- a/src/app/(header)/_components/index.scss
+++ b/src/app/(header)/_components/index.scss
@@ -9,7 +9,7 @@
   }
   &__content {
     margin-top: 1rem;
-    height: 90vh;
-    overflow-y: scroll;
+    height: 87vh;
+    overflow-y: auto;
   }
 }

--- a/src/app/(header)/home/_components/MyPlan.tsx
+++ b/src/app/(header)/home/_components/MyPlan.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Dropdown } from '@/components';
+import { Dropdown, Icon, Tag } from '@/components';
 import { GetMyPlansResponse } from '@/types/apis/plan/GetMyPlans';
 import classNames from 'classnames';
 import { useEffect, useState } from 'react';
@@ -18,6 +18,7 @@ export default function MyPlan({ myPlans }: MyPlanProps) {
   const yearList = myPlansData.map((x) => x.year);
   const [period, setPeriod] = useState(yearList[0]);
   const [yearData, setYearData] = useState(myPlansData[0]);
+  const email_isVerified = myPlansData[0].getPlanList[0].isVerified;
   const PERIOD_OPTIONS = yearList.map((x) => {
     return { value: x, name: `${x}년 계획` };
   });
@@ -71,6 +72,17 @@ export default function MyPlan({ myPlans }: MyPlanProps) {
           },
         )}
       </div>
+      {email_isVerified ? (
+        <h1 className={classNames('home-email-isVerified')}>
+          현재 <Tag color="green-300">이메일</Tag>을 통해서 리마인드를 받고
+          있어요
+        </h1>
+      ) : (
+        <h1 className={classNames('home-email-isVerified')}>
+          <Icon name="WARNING" size="xl" />
+          현재 인증된 이메일이 없습니다.
+        </h1>
+      )}
     </>
   );
 }

--- a/src/app/(header)/home/_components/index.scss
+++ b/src/app/(header)/home/_components/index.scss
@@ -23,4 +23,11 @@
     grid-template-rows: repeat(2, 17.5rem);
     grid-template-columns: repeat(2, 20rem);
   }
+  &-email-isVerified {
+    display: flex;
+    align-items: center;
+    gap: 0.2rem;
+    height: 1.5rem;
+    margin: 0.5rem 0;
+  }
 }


### PR DESCRIPTION
## 📌 이슈 번호

close #132 

## 🚀 구현 내용
- 이메일 인증 여부 추가했습니다.
- 헤더의 최상위 레이아웃 height 조절했고, 스크롤 요소는 넘칠때만 적용되도록 했습니다.
## 📘 참고 사항
<img width="679" alt="image" src="https://github.com/New-Barams/this-year-ajaja-fe/assets/67812466/10d65d72-8281-4c9e-a9e5-2b47c2a2b86c">
<img width="608" alt="image" src="https://github.com/New-Barams/this-year-ajaja-fe/assets/67812466/536a8896-8f98-4e42-a58d-f32def4e03c4">

<!--## ❓ 궁금한 내용-->
