### PR TITLE
[민우] - 각 페이지 진입 및 완료 로직

### DIFF
--- a/src/app/(header)/create/page.tsx
+++ b/src/app/(header)/create/page.tsx
@@ -104,7 +104,7 @@ export default function CreatePage() {
 
   // 계획 생성 API 부분
   const { mutate: createNewPlanAPI } = usePostNewPlanMutation();
-  const handleCreateNewPlan = () => {
+  const handleClickCreateButton = () => {
     const data: PostNewPlanRequestBody = {
       iconNumber: decideRandomIconNumber(),
       isPublic: isPublic,
@@ -154,7 +154,7 @@ export default function CreatePage() {
             size="lg"
             border={false}
             onClick={() => {
-              handleCreateNewPlan();
+              handleClickCreateButton();
             }}
             disabled={!isCreatePossible}>
             작성 완료

--- a/src/app/(header)/edit/[planId]/page.tsx
+++ b/src/app/(header)/edit/[planId]/page.tsx
@@ -144,7 +144,7 @@ export default function EditPage({ params }: { params: { planId: string } }) {
     isAllRemindMessageExists && title.length !== 0 && description.length !== 0;
 
   // 3. 수정된 state들을 가지고 호출하는 계획 수정 API
-  const { mutate: editPlanAPI } = useEditPlanMutation();
+  const { mutate: editPlanAPI } = useEditPlanMutation(parseInt(planId, 10));
 
   const editPlan = () => {
     const editPlanData: EditPlanData = {

--- a/src/app/(header)/home/_components/MyPlan.tsx
+++ b/src/app/(header)/home/_components/MyPlan.tsx
@@ -31,6 +31,7 @@ export default function MyPlan({ myPlans }: MyPlanProps) {
     <>
       <div className={classNames(`home__wrapper-dropdown`)}>
         <Dropdown
+          dropdownId="homePageDropdown"
           options={PERIOD_OPTIONS}
           selectedValue={period}
           setSelectedValue={setPeriod}

--- a/src/app/(header)/plans/[planId]/page.tsx
+++ b/src/app/(header)/plans/[planId]/page.tsx
@@ -21,7 +21,6 @@ export default function PlanIdPage({ params }: { params: { planId: string } }) {
   const { planId } = params;
   const router = useRouter();
   const isSeason = checkIsSeason();
-
   const { plan } = useGetPlanQuery(Number(planId));
   const isMyPlan = checkIsMyPlan(plan.userId);
 
@@ -32,7 +31,7 @@ export default function PlanIdPage({ params }: { params: { planId: string } }) {
   const handleModalClickYes = () => {
     setIsDeletePlanModalOpen(false);
     deletePlanAPI(parseInt(planId, 10));
-    router.replace('/home'); // TODO: 계획 삭제 했으니 상세 페이지 이전으로 1단계 이동하려고 back으로 했는데 일단 잘 안되서 /home으로 변경
+    router.push('/home');
   };
 
   const handleModalClickNo = () => {

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -12,6 +12,7 @@ type optionsType = {
 };
 
 interface DropdownProps {
+  dropdownId: string;
   options: optionsType[];
   selectedValue: number;
   setSelectedValue: (newSelectedValue: number) => void;
@@ -19,6 +20,7 @@ interface DropdownProps {
 }
 
 export default function Dropdown({
+  dropdownId,
   options,
   selectedValue,
   setSelectedValue,
@@ -66,7 +68,7 @@ export default function Dropdown({
       className={classNames('dropdown__container', classNameList)}
       ref={backgroundRef}>
       <input
-        id="dropdown"
+        id={dropdownId}
         className="dropdown__checkbox"
         type="checkbox"
         checked={isDropdownOpened}
@@ -74,7 +76,7 @@ export default function Dropdown({
       />
       <label
         className={classNames('dropdown__label', 'background-origin-white-100')}
-        htmlFor="dropdown"
+        htmlFor={dropdownId}
         onClick={handleClickLabel}>
         <div className="dropdown__label__text">
           {selectedOptionName(selectedValue)}

--- a/src/components/Remind/ReadOnlyRemind/ReadOnlyRemind.tsx
+++ b/src/components/Remind/ReadOnlyRemind/ReadOnlyRemind.tsx
@@ -40,7 +40,9 @@ export default function ReadOnlyRemind({ planId }: ReadOnlyRemindProps) {
     checkIsSeason(),
   );
 
-  const { mutate: toggleIsRemindableAPI } = useToggleIsRemindableMutation();
+  const { mutate: toggleIsRemindableAPI } = useToggleIsRemindableMutation(
+    parseInt(planId, 10),
+  );
 
   const handleToggleIsRemindable = () => {
     toggleIsRemindableAPI(parseInt(planId, 10));

--- a/src/components/Remind/WritableRemind/WritableRemind.tsx
+++ b/src/components/Remind/WritableRemind/WritableRemind.tsx
@@ -106,6 +106,7 @@ export default function WritableRemind({
 
         <div className={classNames('writable-remind__options')}>
           <Dropdown
+            dropdownId="remindPeriodDropdown"
             options={TOTAL_PERIOD_OPTIONS}
             selectedValue={remindOption.TotalPeriod}
             setSelectedValue={(newSelectedValue: number) => {
@@ -117,6 +118,7 @@ export default function WritableRemind({
             동안
           </span>
           <Dropdown
+            dropdownId="remindTermDropdown"
             options={filteredTermOptions}
             selectedValue={remindOption.Term}
             setSelectedValue={(newSelectedValue: number) => {
@@ -128,6 +130,7 @@ export default function WritableRemind({
             마다 매달
           </span>
           <Dropdown
+            dropdownId="remindDateDropdown"
             options={DATE_OPTIONS}
             selectedValue={remindOption.Date}
             setSelectedValue={(newSelectedValue: number) => {
@@ -136,6 +139,7 @@ export default function WritableRemind({
             classNameList={['writable-remind__options__dropdown']}
           />
           <Dropdown
+            dropdownId="remindTimeDropdown"
             options={TIME_OPTIONS}
             selectedValue={remindOption.Time}
             setSelectedValue={(newSelectedValue: number) => {

--- a/src/hooks/apis/useDeletePlanMutation.ts
+++ b/src/hooks/apis/useDeletePlanMutation.ts
@@ -1,8 +1,15 @@
 import { deletePlan } from '@/apis/client/deletePlan';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useDeletePlanMutation = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: deletePlan,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['getMyPlans'],
+      }); // getMyPlans 쿼리(홈 페이지) 무효화
+    },
   });
 };

--- a/src/hooks/apis/useEditPlanMutation.ts
+++ b/src/hooks/apis/useEditPlanMutation.ts
@@ -1,8 +1,18 @@
 import { editPlan } from '@/apis/client/editPlan';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-export const useEditPlanMutation = () => {
+export const useEditPlanMutation = (planId: number) => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: editPlan,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [{ planId: planId }],
+      }); // planId에 해당하는 getPlan 쿼리, getRemind 쿼리 무효화
+      queryClient.invalidateQueries({
+        queryKey: ['getMyPlans'],
+      }); // getMyPlans 쿼리(홈 페이지) 무효화
+    },
   });
 };

--- a/src/hooks/apis/useGetPlanQuery.ts
+++ b/src/hooks/apis/useGetPlanQuery.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 export const useGetPlanQuery = (id: number) => {
   const { data, isFetching, isError } = useQuery({
-    queryKey: ['plan', id],
+    queryKey: [{ planId: id }, 'getPlan'],
     queryFn: () => getPlan(id),
   });
   return { plan: data!.data, isFetching, isError };

--- a/src/hooks/apis/useGetRemindQuery.ts
+++ b/src/hooks/apis/useGetRemindQuery.ts
@@ -4,10 +4,11 @@ import { useQuery } from '@tanstack/react-query';
 
 export const useGetRemindQuery = (planId: number, isSeason: boolean) => {
   const { data } = useQuery({
-    queryKey: ['getRemind', planId],
+    queryKey: [{ planId: planId }, 'getRemind', { isSeason: isSeason }],
     queryFn: () => {
       return isSeason ? getRemindSeason(planId) : getRemindAfterSeason(planId);
     },
+    staleTime: 300000, // TODO: 최대한 길게 해도 될 것 같음
   });
 
   return { remindData: data!.data };

--- a/src/hooks/apis/useGetRemindQuery.ts
+++ b/src/hooks/apis/useGetRemindQuery.ts
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 
 export const useGetRemindQuery = (planId: number, isSeason: boolean) => {
   const { data } = useQuery({
-    queryKey: ['getRemind', planId], // TODO: plan 마다 캐시 관리 ?
+    queryKey: ['getRemind', planId],
     queryFn: () => {
       return isSeason ? getRemindSeason(planId) : getRemindAfterSeason(planId);
     },

--- a/src/hooks/apis/usePostNewPlanMutation.ts
+++ b/src/hooks/apis/usePostNewPlanMutation.ts
@@ -1,8 +1,15 @@
 import { postNewPlan } from '@/apis/client/postNewPlan';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const usePostNewPlanMutation = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: postNewPlan,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['getMyPlans'],
+      }); // getMyPlans 쿼리(홈 페이지) 무효화
+    },
   });
 };

--- a/src/hooks/apis/useToggleIsRemindable.ts
+++ b/src/hooks/apis/useToggleIsRemindable.ts
@@ -1,8 +1,15 @@
 import { toggleIsRemindable } from '@/apis/client/toggleIsRemindable';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-export const useToggleIsRemindableMutation = () => {
+export const useToggleIsRemindableMutation = (planId: number) => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: toggleIsRemindable,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [{ planId: planId }, 'getRemind'],
+      }); // TODO: planId에 해당하는  getRemind 쿼리 무효화 => 안 하는게 좋을 지도 ?
+    },
   });
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { checkIsSeason } from './utils/checkIsSeason';
+
+export function middleware(request: NextRequest) {
+  const cookies = request.cookies;
+
+  if (request.nextUrl.pathname === '/') {
+    if (cookies.has('auth')) {
+      return NextResponse.redirect(new URL('/home', request.url));
+    }
+    return NextResponse.redirect(new URL('/login', request.url));
+  } else if (request.nextUrl.pathname === '/home') {
+    if (!cookies.has('auth')) {
+      return NextResponse.redirect(new URL('/login', request.url));
+    }
+  } else if (
+    request.nextUrl.pathname === '/create' ||
+    request.nextUrl.pathname.startsWith('/edit')
+  ) {
+    if (!cookies.has('auth')) {
+      return NextResponse.redirect(new URL('/login', request.url));
+    }
+
+    if (!checkIsSeason()) {
+      return NextResponse.redirect(new URL('/home', request.url));
+    }
+  } else if (request.nextUrl.pathname === '/my') {
+    if (!cookies.has('auth')) {
+      return NextResponse.redirect(new URL('/login', request.url));
+    }
+  } else if (request.nextUrl.pathname === '/login') {
+    if (cookies.has('auth')) {
+      return NextResponse.redirect(new URL('/home', request.url));
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/', '/home', '/create', '/edit/:path*', '/my', '/login'],
+};


### PR DESCRIPTION
## 📌 이슈 번호

close #137 

## 🚀 구현 내용
### middleware 리다이렉트 설정
+ `/` 페이지 접근 막음 
=> 쿠키에 auth 존재 시 `home`  OR 쿠키에 auth 존재x `login` 으로 리다이렉트

+ 로그인 안되어있을 시(쿠키에 auth가 존재하지 않을 시)
 `home`, `my`, `create`, `edit` 페이지 접근 => `login` 페이지로 리다이렉트
+ 로그인 되어있을 시(쿠키에 auth가 존재할 경우) 
`login` 페이지 접근 => `home`으로 리다이렉트
+ 시즌이 아닐 때, `create`, `edit` 페이지 접근 => `home`으로 리다이렉트
> 쿠키에 `auth`가 존재할 때(토큰이 존재할 때)도 로그인 만료되었을 수도 있지만, 이는 인터셉터에서 판단하는 게 좋을 것 같고, middleware에서는 지금처럼  **auth의 존재여부**, **시즌 여부**에 따라 바로 판단할 수 있는 로직만 넣었습니다. 추가하거나 삭제해야 할 리다이렉트 조건이나 로직이 있다면 말해주세요 !!

- [x] dropbox 컴포넌트 내 input 태그마다 고유한 id 가지도록
- [x] 리액트 쿼리 키 정의 및 mutate 후 연관된 쿼리 무효화 로직 추가

<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
