### PR TITLE
[혜수] - getAllPlans 토큰이 필요하지 않도록 수정

### DIFF
--- a/src/apis/client/getAllPlans.ts
+++ b/src/apis/client/getAllPlans.ts
@@ -9,7 +9,7 @@ export const getAllPlans = async (query: GetAllPlansRequestQuery) => {
   const { data } = await axiosInstanceClient.get<GetAllPlansResponse>(
     DOMAIN.GET_PLANS_ALL,
     {
-      authorization: true,
+      authorization: false,
       params: {
         ...query,
       },

--- a/src/app/(headerless)/login/page.tsx
+++ b/src/app/(headerless)/login/page.tsx
@@ -8,7 +8,6 @@ import './index.scss';
 export default function LoginPage() {
   return (
     <>
-      (
       <div className="wrapper">
         <div className="login">
           <Image
@@ -46,7 +45,6 @@ export default function LoginPage() {
           </div>
         </div>
       </div>
-      )
     </>
   );
 }


### PR DESCRIPTION
## 📌 이슈 번호

close #154 

## 🚀 구현 내용
- authorization: false로 변경했습니다. (타인 계획 페이지 API는 토큰이 필요 없음)
<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
