### PR TITLE
[혜수] - 이메일 인증여부에 따라 새 계획 생성시 이메일 인증 모달 띄우기 추가

### DIFF
--- a/src/app/(header)/home/_components/MyPlan.tsx
+++ b/src/app/(header)/home/_components/MyPlan.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { Dropdown, Icon, Tag } from '@/components';
+import { Dropdown, Icon, Modal, ModalVerification, Tag } from '@/components';
 import { GetMyPlansResponse } from '@/types/apis/plan/GetMyPlans';
+import { useQueryClient } from '@tanstack/react-query';
 import classNames from 'classnames';
 import { useEffect, useState } from 'react';
 import NewPlan from './NewPlan/NewPlan';
@@ -14,14 +15,26 @@ type MyPlanProps = {
 
 export default function MyPlan({ myPlans }: MyPlanProps) {
   const maxLength = 4;
+  const queryClient = useQueryClient();
   const { data: myPlansData } = myPlans;
   const yearList = myPlansData.map((x) => x.year);
   const [period, setPeriod] = useState(yearList[0]);
   const [yearData, setYearData] = useState(myPlansData[0]);
   const email_isVerified = myPlansData[0].getPlanList[0].isVerified;
+  const [isOpenEmailModal, setIsOpenEmailModal] = useState(false);
   const PERIOD_OPTIONS = yearList.map((x) => {
     return { value: x, name: `${x}년 계획` };
   });
+
+  const handleOpenEmailVerificationModal = () => {
+    if (!email_isVerified) setIsOpenEmailModal(true);
+  };
+  const handleCloseEmailVerificationModal = () => {
+    setIsOpenEmailModal(false);
+  };
+  const handleSetVerifiedEmail = () => {
+    queryClient.invalidateQueries({ queryKey: ['getMyPlans'] });
+  };
 
   useEffect(() => {
     setYearData(myPlansData.find((x) => x.year === period)!);
@@ -69,7 +82,15 @@ export default function MyPlan({ myPlans }: MyPlanProps) {
         {Array.from(
           { length: maxLength - yearData.getPlanList.length },
           (_, i) => {
-            return <NewPlan key={i} />;
+            return (
+              <NewPlan
+                key={i}
+                email_isVerified={email_isVerified}
+                handleOpenEmailVerificationModal={
+                  handleOpenEmailVerificationModal
+                }
+              />
+            );
           },
         )}
       </div>
@@ -83,6 +104,14 @@ export default function MyPlan({ myPlans }: MyPlanProps) {
           <Icon name="WARNING" size="xl" />
           현재 인증된 이메일이 없습니다.
         </h1>
+      )}
+      {isOpenEmailModal && (
+        <Modal>
+          <ModalVerification
+            handleCloseModal={handleCloseEmailVerificationModal}
+            setVerifiedEmail={handleSetVerifiedEmail}
+          />
+        </Modal>
       )}
     </>
   );

--- a/src/app/(header)/home/_components/NewPlan/NewPlan.tsx
+++ b/src/app/(header)/home/_components/NewPlan/NewPlan.tsx
@@ -4,14 +4,23 @@ import classNames from 'classnames';
 import Link from 'next/link';
 import './index.scss';
 
-export default function NewPlan() {
+type NewPlanProps = {
+  email_isVerified: boolean;
+  handleOpenEmailVerificationModal: () => void;
+};
+
+export default function NewPlan({
+  email_isVerified,
+  handleOpenEmailVerificationModal,
+}: NewPlanProps) {
   return (
     <Link
-      href={checkIsSeason() ? '/create' : {}}
+      href={checkIsSeason() && email_isVerified ? '/create' : {}}
       className={classNames('new-plan__wrapper')}
       style={{
         cursor: checkIsSeason() ? 'pointer' : 'default',
-      }}>
+      }}
+      onClick={handleOpenEmailVerificationModal}>
       <div className={classNames('new-plan__wrapper--icon')}>
         <Icon
           name={checkIsSeason() ? 'CREATE_NEW_PLAN' : 'AJAJA'}


### PR DESCRIPTION
## 📌 이슈 번호

close #144 

## 🚀 구현 내용
- 이메일 인증여부에 따라 새 계획 생성 시 이메일 인증 모달 띄우기 추가
## 📘 참고 사항
![image](https://github.com/New-Barams/this-year-ajaja-fe/assets/67812466/ab56705e-a66c-435c-9bbb-f83e6ceed1f4)

<!--## ❓ 궁금한 내용-->
