### PR TITLE
[혜수] - 다른 계획 둘러보기 페이지에서 아좌좌 수 정상적으로 보이도록 변경

### DIFF
--- a/src/app/(header)/explore/_components/Plans/Plans.tsx
+++ b/src/app/(header)/explore/_components/Plans/Plans.tsx
@@ -25,32 +25,30 @@ export default function Plans({ flatLoadedPlans, isLogin }: PlansProps) {
     <div className={classNames('plans__wrapper')}>
       {flatLoadedPlans?.map((plan, index) => {
         return (
-          <>
-            <Link
-              key={index}
-              href={isLogin ? `/plans/${plan.id}` : {}}
-              onClick={() => {
-                handleModal(true);
-              }}>
-              <Card key={index} plan={plan} />
-            </Link>
-            {isOpenModal && (
-              <Modal>
-                <ModalExit
-                  exitLink={`/login`}
-                  closeModal={() => {
-                    setTimeout(() => {
-                      handleModal(false);
-                    }, 100);
-                  }}>
-                  상세 계획을 보려면 로그인이 필요합니다!<br></br>
-                  로그인 하시겠습니까?
-                </ModalExit>
-              </Modal>
-            )}
-          </>
+          <Link
+            key={index}
+            href={isLogin ? `/plans/${plan.id}` : {}}
+            onClick={() => {
+              handleModal(true);
+            }}>
+            <Card key={index} plan={plan} />
+          </Link>
         );
       })}
+      {isOpenModal && (
+        <Modal>
+          <ModalExit
+            exitLink={`/login`}
+            closeModal={() => {
+              setTimeout(() => {
+                handleModal(false);
+              }, 100);
+            }}>
+            상세 계획을 보려면 로그인이 필요합니다!<br></br>
+            로그인 하시겠습니까?
+          </ModalExit>
+        </Modal>
+      )}
     </div>
   );
 }

--- a/src/components/AjajaButton/AjajaButton.tsx
+++ b/src/components/AjajaButton/AjajaButton.tsx
@@ -6,7 +6,7 @@ import { usePostAjajaMutation } from '@/hooks/apis/usePostAjajaMutation';
 import { useDebounce } from '@/hooks/useDebounce';
 import { useQueryClient } from '@tanstack/react-query';
 import classNames from 'classnames';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ButtonHTMLAttributes, PropsWithChildren } from 'react';
 import './index.scss';
 
@@ -52,6 +52,10 @@ export default function AjajaButton({
   };
 
   useDebounce(compare, 500, []);
+
+  useEffect(() => {
+    setCount(ajajaCount);
+  }, [ajajaCount]);
 
   return (
     <button


### PR DESCRIPTION
## 📌 이슈 번호

close #170

## 🚀 구현 내용
- Plans 모달의 위치 map 밖으로 이동 -> 불필요한 반복 제거
- 아좌좌버튼 ajajaCount가 변경되었을 때 count도 함께 변경
<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
