### PR TITLE
[민우] - 리액트 쿼리 error handling

### DIFF
--- a/src/app/(header)/edit/[planId]/error.tsx
+++ b/src/app/(header)/edit/[planId]/error.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { BasicError } from '@/components';
+import { useEffect } from 'react';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return <BasicError reset={reset} />;
+}

--- a/src/app/(header)/plans/[planId]/error.tsx
+++ b/src/app/(header)/plans/[planId]/error.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { BasicError } from '@/components';
+import { useEffect } from 'react';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return <BasicError reset={reset} />;
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { BasicError } from '@/components';
+import { useEffect } from 'react';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return <BasicError reset={reset} />;
+}

--- a/src/hooks/apis/useDeletePlanMutation.ts
+++ b/src/hooks/apis/useDeletePlanMutation.ts
@@ -12,5 +12,6 @@ export const useDeletePlanMutation = () => {
         queryKey: [QUERY_KEY.MY_PLANS],
       });
     },
+    throwOnError: true,
   });
 };

--- a/src/hooks/apis/useEditPlanMutation.ts
+++ b/src/hooks/apis/useEditPlanMutation.ts
@@ -17,5 +17,6 @@ export const useEditPlanMutation = (planId: number) => {
         }),
       ]);
     },
+    throwOnError: true,
   });
 };

--- a/src/hooks/apis/useGetRemindQuery.ts
+++ b/src/hooks/apis/useGetRemindQuery.ts
@@ -1,10 +1,10 @@
 import { getRemindAfterSeason } from '@/apis/client/getRemindAfterSeason';
 import { getRemindSeason } from '@/apis/client/getRemindSeason';
 import { QUERY_KEY } from '@/constants/queryKey';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 export const useGetRemindQuery = (planId: number, isSeason: boolean) => {
-  const { data } = useQuery({
+  const { data } = useSuspenseQuery({
     queryKey: [{ planId: planId }, QUERY_KEY.REMIND, { isSeason: isSeason }],
     queryFn: () => {
       return isSeason ? getRemindSeason(planId) : getRemindAfterSeason(planId);

--- a/src/hooks/apis/useToggleAjajaNotificationMutation.ts
+++ b/src/hooks/apis/useToggleAjajaNotificationMutation.ts
@@ -12,5 +12,6 @@ export const useToggleAjajaNotificationMutation = (planId: number) => {
         queryKey: [{ planId: planId }, QUERY_KEY.PLAN],
       });
     },
+    throwOnError: true,
   });
 };

--- a/src/hooks/apis/useToggleIsPublicMutation.ts
+++ b/src/hooks/apis/useToggleIsPublicMutation.ts
@@ -12,5 +12,6 @@ export const useToggleIsPublicMutation = (planId: number) => {
         queryKey: [{ planId: planId }, QUERY_KEY.PLAN],
       });
     },
+    throwOnError: true,
   });
 };

--- a/src/hooks/apis/useToggleIsRemindable.ts
+++ b/src/hooks/apis/useToggleIsRemindable.ts
@@ -12,5 +12,6 @@ export const useToggleIsRemindableMutation = (planId: number) => {
         queryKey: [{ planId: planId }, QUERY_KEY.REMIND],
       });
     },
+    throwOnError: true,
   });
 };

--- a/src/provider/TanstackQueryProvider.tsx
+++ b/src/provider/TanstackQueryProvider.tsx
@@ -4,13 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import React from 'react';
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      suspense: true,
-    },
-  },
-});
+const queryClient = new QueryClient();
 
 export default function TanstackQueryProvider({
   children,


### PR DESCRIPTION
## 📌 이슈 번호

close #183 

## 🚀 구현 내용
- [ ] 계획 수정, 상세 페이지 error 바운더리 추가
- [ ] queryClient suspense 옵션 삭제
- [ ] useQuery => useSuspenseQuery 로 변경
- [ ] throwOnError true로 설정 => 각 페이지 error 바운더리에서 catch할 수 있도록

<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
