### PR TITLE
[노철] - react query 에러핸들링

### DIFF
--- a/src/app/(header)/my/error.tsx
+++ b/src/app/(header)/my/error.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { BasicError } from '@/components';
+
+export default function ErrorPage({
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  return <BasicError reset={reset} />;
+}

--- a/src/components/ModalVerification/ModalVerification.tsx
+++ b/src/components/ModalVerification/ModalVerification.tsx
@@ -4,9 +4,8 @@ import { Button, Icon } from '@/components';
 import { usePostSendVerificationMutation } from '@/hooks/apis/usePostSendVerificationMutation';
 import { usePostVerifyMutation } from '@/hooks/apis/usePostVerifyMutation';
 import { checkEmailValidation } from '@/utils/checkEmailValidation';
-import { AxiosError } from 'axios';
 import classNames from 'classnames';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import './index.scss';
 
 interface ModalVerificationProps {
@@ -36,6 +35,26 @@ export default function ModalVerification({
   const [code, setCode] = useState<string>('');
   const [isValidEmail, setIsValidEmail] = useState<boolean>(true);
   const [isValidCode, setIsValidCode] = useState<boolean>(true);
+
+  useEffect(() => {
+    if (error && error.response) {
+      const status = error.response.status;
+      if (status <= 400 || status >= 500) {
+        throw error;
+      }
+    } else if (error) {
+      throw error;
+    }
+    if (verifyError && verifyError.response) {
+      const status = verifyError.response.status;
+      if (status <= 400 || status >= 500) {
+        throw verifyError;
+      }
+    } else if (verifyError) {
+      throw verifyError;
+    }
+  }, [error, verifyError]);
+
   const handleChangeEmail = (event: React.ChangeEvent<HTMLInputElement>) => {
     setEmail(event.target.value);
   };
@@ -56,12 +75,7 @@ export default function ModalVerification({
   const handleSubmitCode = async () => {
     if (code.length == 6) {
       setIsValidCode(true);
-      await submitCertification(code).catch((error: AxiosError) => {
-        if (error && error.response) {
-          const status = error.response.status;
-          if (status <= 400 || status >= 500) throw error;
-        }
-      });
+      await submitCertification(code);
       setVerifiedEmail && setVerifiedEmail();
     } else {
       setIsValidCode(false);

--- a/src/hooks/apis/useGetPlanQuery.ts
+++ b/src/hooks/apis/useGetPlanQuery.ts
@@ -1,9 +1,9 @@
 import { getPlan } from '@/apis/client/getPlan';
 import { QUERY_KEY } from '@/constants/queryKey';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 export const useGetPlanQuery = (id: number) => {
-  const { data, isFetching, isError } = useQuery({
+  const { data, isFetching, isError } = useSuspenseQuery({
     queryKey: [{ planId: id }, QUERY_KEY.PLAN],
     queryFn: () => getPlan(id),
     staleTime: Infinity,

--- a/src/hooks/apis/useGetUserInformationQuery.ts
+++ b/src/hooks/apis/useGetUserInformationQuery.ts
@@ -1,9 +1,9 @@
 import { getUserInformation } from '@/apis/client/getUserInformation';
 import { QUERY_KEY } from '@/constants/queryKey';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 export const useGetUserInformationQuery = () => {
-  const { data, isError, isFetching, error } = useQuery({
+  const { data, isError, isFetching, error } = useSuspenseQuery({
     queryKey: [QUERY_KEY.USER_INFORMATION],
     queryFn: getUserInformation,
     staleTime: Infinity,

--- a/src/hooks/apis/useRefreshNicknameMutation.ts
+++ b/src/hooks/apis/useRefreshNicknameMutation.ts
@@ -4,6 +4,7 @@ import { useMutation } from '@tanstack/react-query';
 export const usePostUsersRefreshMutation = () => {
   const { mutate, isPending } = useMutation({
     mutationFn: postUsersRefresh,
+    throwOnError: true,
   });
 
   return { refreshNickname: mutate, isPending };


### PR DESCRIPTION
## 📌 이슈 번호

close #184 

## 🚀 구현 내용
- useGetPlanquery ,useGetUSerInformationquery =>  useSuspense 교체
- 에러페이지 추가
- useRefreshNicknameMutaion => throwOnError: true 
- mutation 시 특정 에러 throw 처리   

바운더리에 전달되지 않는 문제는 useEffect로 해결했습니다. 
<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
