### PR TITLE
[노철] -  회원탈퇴 api

### DIFF
--- a/src/app/(header)/my/page.tsx
+++ b/src/app/(header)/my/page.tsx
@@ -14,7 +14,6 @@ import { QUERY_KEY } from '@/constants/queryKey';
 import { useGetUserInformationQuery } from '@/hooks/apis/useGetUserInformationQuery';
 import { usePostUsersRefreshMutation } from '@/hooks/apis/useRefreshNicknameMutation';
 import { useQueryClient } from '@tanstack/react-query';
-import { deleteCookie } from 'cookies-next';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
@@ -60,10 +59,10 @@ export default function MyPage() {
   const handleWithdrawal = () => {
     setIsOpenWithdrawalModal(true);
   };
-  const handleRealWithdrawal = async () => {
-    await deleteUsers();
-    deleteCookie('auth');
-    router.push('/login');
+  const handleRealWithdrawal = () => {
+    deleteUsers().then(() => {
+      router.push('/oauth?way=logout');
+    });
   };
   const handleCloseWithdrawalModal = () => {
     setIsOpenWithdrawalModal(false);

--- a/src/app/(header)/my/page.tsx
+++ b/src/app/(header)/my/page.tsx
@@ -23,7 +23,7 @@ export default function MyPage() {
   const queryClient = useQueryClient();
   const { userInformation } = useGetUserInformationQuery();
   const { refreshNickname, isPending } = usePostUsersRefreshMutation();
-  const { isEmailVerified, nickname, remindEmail } = userInformation;
+  const { emailVerified, nickname, remindEmail } = userInformation;
 
   const [isOpenEmailModal, setIsOpenEmailModal] = useState<boolean>(false);
   const [isOpenLogOutModal, setIsOpenLogOutModal] = useState<boolean>(false);
@@ -107,7 +107,7 @@ export default function MyPage() {
           </div>
 
           <div className="my-page__remind-way">
-            {isEmailVerified ? (
+            {emailVerified ? (
               <h1>
                 현재 <Tag color="green-300">이메일</Tag>을 통해서 리마인드를
                 받고 있어요
@@ -127,7 +127,7 @@ export default function MyPage() {
         <div className="my-page__email">
           <h1 className="font-size-2xl">
             이메일:
-            {isEmailVerified ? remindEmail : '  ---'}
+            {emailVerified ? remindEmail : '  ---'}
           </h1>
           <Button
             size="sm"
@@ -135,7 +135,7 @@ export default function MyPage() {
             color="white-100"
             border={true}
             onClick={handleGoEmailVerification}>
-            {isEmailVerified ? '이메일 변경하기' : '이메일 인증하기'}
+            {emailVerified ? '이메일 변경하기' : '이메일 인증하기'}
           </Button>
         </div>
 

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -8,7 +8,7 @@ export const DOMAIN = {
   POST_USERS_SEND_VERIFICATION: '/users/send-verification',
   POST_USERS_REFRESH: '/users/refresh',
   POST_USERS_LOGOUT: '/users/logout',
-  DELETE_USERS: '/mock/users',
+  DELETE_USERS: '/users',
   GET_USERS: '/users',
 
   POST_FEEDBACKS: (feedbackId: number) => `/feedbacks/${feedbackId}`,

--- a/src/types/apis/users/GetUserInformation.ts
+++ b/src/types/apis/users/GetUserInformation.ts
@@ -6,7 +6,7 @@ interface User {
   nickname: string;
   defaultEmail: string;
   remindEmail: string;
-  isEmailVerified: boolean;
+  emailVerified: boolean;
   receiveType: ReceiveType;
 }
 


### PR DESCRIPTION
## 📌 이슈 번호

close #204 

## 🚀 구현 내용

- 회원 탈퇴 후 로그아웃 진행 
- 유저정보 변수명 변경 ( 스웨거 기준)
  - isEmailVerified=> emailVerified
## 📘 참고 사항

이전에 있었던  회원탙퇴가 안되던 이슈는 
회원 탈퇴 api를 구현해 놓고 목으로 연결해서 안됐던 것 같습니다. 

<!--## ❓ 궁금한 내용-->
