### PR TITLE
[민우] - 작성, 수정, 상세 페이지 디자인 수정 및 에러 해결 및 토스트 적용

### DIFF
--- a/src/app/(header)/create/index.scss
+++ b/src/app/(header)/create/index.scss
@@ -1,5 +1,7 @@
 .create-page {
-  padding:  1.75rem 2.5rem;
+  padding: 1.75rem 2.5rem;
+  display: flex;
+  flex-direction: column;
 
   &__remind {
     &:before {
@@ -13,7 +15,7 @@
   }
 
   &__button__container {
-    margin-top: 4rem;
+    margin-top: 2rem;
     display: flex;
     justify-content: center;
     gap: 13rem;

--- a/src/app/(header)/create/index.scss
+++ b/src/app/(header)/create/index.scss
@@ -1,5 +1,6 @@
 .create-page {
   padding: 1.75rem 2.5rem;
+  height: 100%;
   display: flex;
   flex-direction: column;
 

--- a/src/app/(header)/create/index.scss
+++ b/src/app/(header)/create/index.scss
@@ -3,6 +3,7 @@
   height: 100%;
   display: flex;
   flex-direction: column;
+  overflow: auto;
 
   &__remind {
     &:before {

--- a/src/app/(header)/create/index.scss
+++ b/src/app/(header)/create/index.scss
@@ -1,5 +1,5 @@
 .create-page {
-  padding: 2.5rem;
+  padding:  1.75rem 2.5rem;
 
   &__remind {
     &:before {
@@ -8,7 +8,7 @@
       height: 0.3px;
       background-color: var(--origin-gray-100);
       border: 1px solid var(--origin-gray-100);
-      margin: 3rem 0 3rem 0;
+      margin: 2rem 0 2rem 0;
     }
   }
 

--- a/src/app/(header)/create/page.tsx
+++ b/src/app/(header)/create/page.tsx
@@ -11,11 +11,12 @@ import { changeRemindTimeToString } from '@/utils/changeRemindTimeToString';
 import { decideRandomIconNumber } from '@/utils/decideRandomIconNumber';
 import { decideRemindDate } from '@/utils/decideRemindDate';
 import classNames from 'classnames';
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useCallback, useState } from 'react';
 import './index.scss';
 
 export default function CreatePage() {
+  const router = useRouter();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [tags, setTags] = useState<string[]>([]);
@@ -102,24 +103,30 @@ export default function CreatePage() {
     isAllRemindMessageExists && title.length !== 0 && description.length !== 0;
 
   const { mutate: createNewPlanAPI } = usePostNewPlanMutation();
-  const handleClickCreateButton = () => {
-    const data: PostNewPlanRequestBody = {
-      iconNumber: decideRandomIconNumber(),
-      isPublic: isPublic,
-      title: title,
-      description: description,
-      tags: tags,
-      remindTotalPeriod: remindOptions.TotalPeriod,
-      remindTerm: remindOptions.Term,
-      remindDate: remindOptions.Date,
-      remindTime: changeRemindTimeToString(remindOptions.Time),
-      messages: remindMessageList.map((messageItem) => {
-        return messageItem.message;
-      }),
-    };
 
-    createNewPlanAPI(data);
-    ajajaToast.success('새 계획 생성 완료');
+  const handleClickCreateButton = () => {
+    if (isCreatePossible) {
+      const data: PostNewPlanRequestBody = {
+        iconNumber: decideRandomIconNumber(),
+        isPublic: isPublic,
+        title: title,
+        description: description,
+        tags: tags,
+        remindTotalPeriod: remindOptions.TotalPeriod,
+        remindTerm: remindOptions.Term,
+        remindDate: remindOptions.Date,
+        remindTime: changeRemindTimeToString(remindOptions.Time),
+        messages: remindMessageList.map((messageItem) => {
+          return messageItem.message;
+        }),
+      };
+
+      createNewPlanAPI(data);
+
+      router.push('/home');
+    } else {
+      ajajaToast.error('모든 항목을 입력해주세요 !');
+    }
   };
 
   return (
@@ -146,19 +153,16 @@ export default function CreatePage() {
         classNameList={['create-page__remind']}
       />
       <div className={classNames('create-page__button__container')}>
-        <Link href="/home">
-          <Button
-            background={isCreatePossible ? 'primary' : 'gray-200'}
-            color="white-100"
-            size="lg"
-            border={false}
-            onClick={() => {
-              handleClickCreateButton();
-            }}
-            disabled={!isCreatePossible}>
-            작성 완료
-          </Button>
-        </Link>
+        <Button
+          background={isCreatePossible ? 'primary' : 'gray-200'}
+          color="white-100"
+          size="lg"
+          border={false}
+          onClick={() => {
+            handleClickCreateButton();
+          }}>
+          작성 완료
+        </Button>
         <Button
           background="primary"
           color="white-100"

--- a/src/app/(header)/create/page.tsx
+++ b/src/app/(header)/create/page.tsx
@@ -50,19 +50,18 @@ export default function CreatePage() {
     day: number,
     newMessage: string,
   ) => {
-    const newRemindList = remindMessageList.map((item) => {
-      if (item.date.month === month && item.date.day === day) {
-        return { ...item, message: newMessage };
-      }
-      return item;
+    setRemindMessageList((prevRemindMessageList) => {
+      return prevRemindMessageList.map((item) => {
+        if (item.date.month === month && item.date.day === day) {
+          return { ...item, message: newMessage };
+        }
+        return item;
+      });
     });
-
-    setRemindMessageList(newRemindList);
   };
 
   const [isExitModalOpen, setIsExitModalOpen] = useState(false);
 
-  // 리마인드 옵션 확정버튼 클릭 시 이에 따라 리마인드 날짜 생성 및 리마인드 아이템 렌더링해주는 함수
   const fixRemindOptions = () => {
     const fixedRemindDate = decideRemindDate(
       remindOptions.TotalPeriod,
@@ -71,6 +70,7 @@ export default function CreatePage() {
     );
 
     const newRemindMessageList: RemindItemType[] = [];
+
     fixedRemindDate?.forEach((newDate) => {
       newRemindMessageList.push({
         date: {
@@ -85,16 +85,14 @@ export default function CreatePage() {
   };
 
   const makeAllRemindMessageSame = useCallback(() => {
-    if (remindMessageList.length <= 1) {
-      return;
-    }
-    const firstRemindMessage = remindMessageList[0].message;
-    const updatedList = remindMessageList.map((item) => {
-      return { ...item, message: firstRemindMessage };
+    setRemindMessageList((prevList) => {
+      if (prevList.length > 1) {
+        const firstMessage = prevList[0].message;
+        return prevList.map((item) => ({ ...item, message: firstMessage }));
+      }
+      return prevList;
     });
-
-    setRemindMessageList(updatedList);
-  }, [remindMessageList]);
+  }, []);
 
   const isAllRemindMessageExists =
     remindMessageList.length > 0 &&
@@ -103,7 +101,6 @@ export default function CreatePage() {
   const isCreatePossible =
     isAllRemindMessageExists && title.length !== 0 && description.length !== 0;
 
-  // 계획 생성 API 부분
   const { mutate: createNewPlanAPI } = usePostNewPlanMutation();
   const handleClickCreateButton = () => {
     const data: PostNewPlanRequestBody = {

--- a/src/app/(header)/edit/[planId]/index.scss
+++ b/src/app/(header)/edit/[planId]/index.scss
@@ -1,5 +1,6 @@
 .edit-page {
   padding: 1.75rem 2.5rem;
+  height: 100%;
   display: flex;
   flex-direction: column;
 

--- a/src/app/(header)/edit/[planId]/index.scss
+++ b/src/app/(header)/edit/[planId]/index.scss
@@ -1,5 +1,7 @@
 .edit-page {
   padding: 1.75rem 2.5rem;
+  display: flex;
+  flex-direction: column;
 
   &__remind {
     &:before {

--- a/src/app/(header)/edit/[planId]/index.scss
+++ b/src/app/(header)/edit/[planId]/index.scss
@@ -1,5 +1,5 @@
 .edit-page {
-  padding: 2.5rem;
+  padding: 1.75rem 2.5rem;
 
   &__remind {
     &:before {
@@ -8,7 +8,7 @@
       height: 0.3px;
       background-color: var(--origin-gray-100);
       border: 1px solid var(--origin-gray-100);
-      margin: 3rem 0 3rem 0;
+      margin: 2rem 0 2rem 0;
     }
   }
 

--- a/src/app/(header)/edit/[planId]/index.scss
+++ b/src/app/(header)/edit/[planId]/index.scss
@@ -3,6 +3,7 @@
   height: 100%;
   display: flex;
   flex-direction: column;
+  overflow: auto;
 
   &__remind {
     &:before {

--- a/src/app/(header)/edit/[planId]/page.tsx
+++ b/src/app/(header)/edit/[planId]/page.tsx
@@ -23,7 +23,6 @@ import './index.scss';
 export default function EditPage({ params }: { params: { planId: string } }) {
   const { planId } = params;
   const router = useRouter();
-  // 1-1. TODO: 계획 단건 조회 API를 통해 계획 data 받아오기
   const { plan: planData } = useGetPlanQuery(Number(planId));
   const isMyPlan = checkIsMyPlan(planData.userId);
   useEffect(() => {
@@ -32,13 +31,11 @@ export default function EditPage({ params }: { params: { planId: string } }) {
     }
   }, [isMyPlan, router]);
 
-  // 1-2. 리마인드 정보 조회 API 호출해서 받아온 data 받아오기
   const { remindData } = useGetRemindQuery(
     parseInt(planId, 10),
     checkIsSeason(),
   );
 
-  // 2. 계획 수정을 위해 관리되어야 하는 state 및 핸들러의 기본값에 1번에서 받은 값을 넣어준다.
   const [title, setTitle] = useState(planData.title);
   const [description, setDescription] = useState(planData.description);
   const [tags, setTags] = useState<string[]>(planData.tags);
@@ -99,14 +96,14 @@ export default function EditPage({ params }: { params: { planId: string } }) {
     day: number,
     newMessage: string,
   ) => {
-    const newRemindList = remindMessageList.map((item) => {
-      if (item.date.month === month && item.date.day === day) {
-        return { ...item, message: newMessage };
-      }
-      return item;
+    setRemindMessageList((prevRemindMessageList) => {
+      return prevRemindMessageList.map((item) => {
+        if (item.date.month === month && item.date.day === day) {
+          return { ...item, message: newMessage };
+        }
+        return item;
+      });
     });
-
-    setRemindMessageList(newRemindList);
   };
 
   const [isExitModalOpen, setIsExitModalOpen] = useState(false);
@@ -133,17 +130,14 @@ export default function EditPage({ params }: { params: { planId: string } }) {
   };
 
   const makeAllRemindMessageSame = useCallback(() => {
-    if (remindMessageList.length <= 1) {
-      return;
-    }
-
-    const firstRemindMessage = remindMessageList[0].message;
-    const updatedList = remindMessageList.map((item) => {
-      return { ...item, message: firstRemindMessage };
+    setRemindMessageList((prevList) => {
+      if (prevList.length > 1) {
+        const firstMessage = prevList[0].message;
+        return prevList.map((item) => ({ ...item, message: firstMessage }));
+      }
+      return prevList;
     });
-
-    setRemindMessageList(updatedList);
-  }, [remindMessageList]);
+  }, []);
 
   const isAllRemindMessageExists =
     remindMessageList.length > 0 &&
@@ -152,7 +146,6 @@ export default function EditPage({ params }: { params: { planId: string } }) {
   const isEditPossible =
     isAllRemindMessageExists && title.length !== 0 && description.length !== 0;
 
-  // 3. 수정된 state들을 가지고 호출하는 계획 수정 API
   const { mutate: editPlanAPI } = useEditPlanMutation(parseInt(planId, 10));
 
   const editPlan = () => {

--- a/src/app/(header)/edit/[planId]/page.tsx
+++ b/src/app/(header)/edit/[planId]/page.tsx
@@ -2,7 +2,6 @@
 
 import { Button, Modal, WritableRemind } from '@/components';
 import ModalExit from '@/components/Modal/ModalExit';
-import { ajajaToast } from '@/components/Toaster/customToast';
 import WritablePlan from '@/components/WritablePlan/WritablePlan';
 import { useEditPlanMutation } from '@/hooks/apis/useEditPlanMutation';
 import { useGetPlanQuery } from '@/hooks/apis/useGetPlanQuery';
@@ -166,9 +165,6 @@ export default function EditPage({ params }: { params: { planId: string } }) {
     };
 
     editPlanAPI({ planId: parseInt(planId, 10), planData: editPlanData });
-    ajajaToast.success('계획 수정 완료');
-
-    console.log(`${planId}에 해당하는 계획 수정 API 호출 `);
   };
 
   return (

--- a/src/app/(header)/plans/[planId]/index.scss
+++ b/src/app/(header)/plans/[planId]/index.scss
@@ -1,5 +1,5 @@
 .plans-page {
-  padding: 2.5rem;
+  padding: 1.75rem 2.5rem;
   display: flex;
   flex-direction: column;
 
@@ -10,7 +10,7 @@
       height: 0.3px;
       background-color: var(--origin-gray-100);
       border: 1px solid var(--origin-gray-100);
-      margin: 3rem 0 3rem 0;
+      margin: 2rem 0 2rem 0;
     }
   }
 

--- a/src/app/(header)/plans/[planId]/index.scss
+++ b/src/app/(header)/plans/[planId]/index.scss
@@ -3,6 +3,7 @@
   height: 100%;
   display: flex;
   flex-direction: column;
+  overflow: auto;
 
   &__remind {
     &:before {

--- a/src/app/(header)/plans/[planId]/index.scss
+++ b/src/app/(header)/plans/[planId]/index.scss
@@ -1,5 +1,6 @@
 .plans-page {
   padding: 1.75rem 2.5rem;
+  height: 100%;
   display: flex;
   flex-direction: column;
 

--- a/src/app/(header)/plans/[planId]/index.scss
+++ b/src/app/(header)/plans/[planId]/index.scss
@@ -15,6 +15,7 @@
   }
 
   &__button__container {
+    margin-top: 2rem;
     display: flex;
     justify-content: center;
     gap: 13rem;

--- a/src/app/(header)/plans/[planId]/page.tsx
+++ b/src/app/(header)/plans/[planId]/page.tsx
@@ -7,7 +7,6 @@ import {
   ReadOnlyPlan,
   ReadOnlyRemind,
 } from '@/components';
-import { ajajaToast } from '@/components/Toaster/customToast';
 import { useDeletePlanMutation } from '@/hooks/apis/useDeletePlanMutation';
 import { useGetPlanQuery } from '@/hooks/apis/useGetPlanQuery';
 import { checkIsMyPlan } from '@/utils/checkIsMyPlan';
@@ -33,7 +32,6 @@ export default function PlanIdPage({ params }: { params: { planId: string } }) {
     setIsDeletePlanModalOpen(false);
     deletePlanAPI(parseInt(planId, 10));
     router.push('/home');
-    ajajaToast.success('계획 삭제 완료');
   };
 
   const handleModalClickNo = () => {

--- a/src/components/Dropdown/index.scss
+++ b/src/components/Dropdown/index.scss
@@ -27,6 +27,7 @@
     padding: 0.5rem 0.75rem;
     border: var(--border-width) solid var(--origin-primary);
     border-radius: var(--border-radius);
+    cursor: pointer;
 
     &__text {
       text-align: center;

--- a/src/components/PlanInput/PlanInput.tsx
+++ b/src/components/PlanInput/PlanInput.tsx
@@ -34,13 +34,15 @@ export default function PlanInput({
       <textarea
         id="planInput"
         readOnly={!editable}
+        disabled={!editable}
         value={textInput}
         onChange={handleChangeInput}
         placeholder={placeholder}
         className={classNames(
           'planInput',
-          { 'planInput--editable': editable },
           `planInput--${kind === 'content' ? 'content' : 'title'}`,
+          { 'planInput--editable': editable },
+          { 'planInput--disabled': !editable },
         )}
       />
       {editable && (

--- a/src/components/PlanInput/index.scss
+++ b/src/components/PlanInput/index.scss
@@ -24,7 +24,13 @@
     height: 10rem;
   }
 
+  &--disabled{
+    border: none;
+    background-color: var(--origin-white-300);
+  }
+
   &--editable {
+    
     &::placeholder {
       opacity: 0;
     }

--- a/src/components/Remind/ReadOnlyRemind/index.scss
+++ b/src/components/Remind/ReadOnlyRemind/index.scss
@@ -22,9 +22,9 @@
 
   &__options {
     display: flex;
-    margin-top: 1rem;
+    margin-top: 1.25rem;
     font-size: 1.5rem;
-    align-items: end;
+    align-items: center;
     gap: 1rem;
 
     &__option {

--- a/src/components/Remind/ReadOnlyRemind/index.scss
+++ b/src/components/Remind/ReadOnlyRemind/index.scss
@@ -24,7 +24,7 @@
     display: flex;
     margin-top: 1.25rem;
     font-size: 1.5rem;
-    align-items: center;
+    align-items: end;
     gap: 1rem;
 
     &__option {

--- a/src/components/Remind/WritableRemind/WritableRemind.tsx
+++ b/src/components/Remind/WritableRemind/WritableRemind.tsx
@@ -167,7 +167,7 @@ export default function WritableRemind({
             onClick={() => {
               handleFixButtonClick();
             }}>
-            확정
+            날짜 확정
           </Button>
         </div>
 
@@ -212,7 +212,7 @@ export default function WritableRemind({
           <ModalBasic
             onClickYes={handleModalClickYes}
             onClickNo={handleModalClickNo}>
-            리마인드 옵션 변경 시 작성한 리마인드 메세지가 모두 삭제됩니다. 정말
+            리마인드 날짜 변경 시 작성한 리마인드 메세지가 모두 삭제됩니다. 정말
             확정하시겠습니까 ?
           </ModalBasic>
         </Modal>

--- a/src/components/Remind/WritableRemind/index.scss
+++ b/src/components/Remind/WritableRemind/index.scss
@@ -26,14 +26,10 @@
 
   &__options {
     display: flex;
-    margin-top: 1rem;
+    margin-top: 1.25rem;
     font-size: 1.5rem;
     align-items: center;
     gap: 1rem;
-
-    &__text {
-      margin-left: 1rem;
-    }
   }
 
   &__message {

--- a/src/components/Remind/WritableRemind/index.scss
+++ b/src/components/Remind/WritableRemind/index.scss
@@ -15,7 +15,7 @@
 
     &__toggle {
       margin-left: 0.5rem;
-      font-size: 0.625rem;
+      font-size: 1rem;
       color: var(--origin-gray-200);
     }
   }

--- a/src/components/RemindInput/RemindInput.tsx
+++ b/src/components/RemindInput/RemindInput.tsx
@@ -38,6 +38,7 @@ export default function RemindInput({
     <textarea
       id="remindInput"
       readOnly={true}
+      disabled
       value={textInput}
       className={classNames('remindInput')}
     />

--- a/src/components/RemindItem/WritableRemindItem/WritableRemindItem.tsx
+++ b/src/components/RemindItem/WritableRemindItem/WritableRemindItem.tsx
@@ -65,7 +65,12 @@ export default function WritableRemindItem({
     if (isFirstRemindItem && isSameMessageChecked) {
       makeAllRemindMessageSame!();
     }
-  }, [isFirstRemindItem, isSameMessageChecked]);
+  }, [
+    isFirstRemindItem,
+    isSameMessageChecked,
+    makeAllRemindMessageSame,
+    remindMessage,
+  ]);
 
   return (
     <>

--- a/src/components/RemindItem/WritableRemindItem/WritableRemindItem.tsx
+++ b/src/components/RemindItem/WritableRemindItem/WritableRemindItem.tsx
@@ -84,7 +84,7 @@ export default function WritableRemindItem({
                   'remind-item__header__warning',
                   'background-origin-primary',
                 )}>
-                <Icon name="WARNING" size="xs" color="white-100" />
+                <Icon name="WARNING" size="base" color="white-100" />
                 <span
                   className={classNames(
                     'remind-item__header__warning__text',
@@ -94,9 +94,6 @@ export default function WritableRemindItem({
                 </span>
               </div>
             )}
-            <span className="remind-item__header__button-text">
-              {isRemindMessageEmpty ? '작성하기' : '수정하기'}
-            </span>
             <Icon
               name={isItemOpened ? 'ITEM_CLOSE' : 'ITEM_OPEN'}
               size="xl"

--- a/src/components/RemindItem/WritableRemindItem/index.scss
+++ b/src/components/RemindItem/WritableRemindItem/index.scss
@@ -31,23 +31,18 @@
       transition: all 1s ease;
       display: flex;
       margin-right: 0.75rem;
-      padding: 0.25rem 0.5rem;
+      padding: 0.5rem 1rem;
       border-radius: var(--border-radius);
+      align-items: center;
 
       &__text {
         margin-left: 0.25rem;
-        font-size: 0.6rem;
+        font-size: 0.8rem;
         line-height: 0.7rem;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-    }
-
-    &__button-text {
-      font-size: 1rem;
-      line-height: 1rem;
-      margin-right: 1.25rem;
     }
 
     &__icon {

--- a/src/components/RemindItem/WritableRemindItem/index.scss
+++ b/src/components/RemindItem/WritableRemindItem/index.scss
@@ -31,7 +31,7 @@
       transition: all 1s ease;
       display: flex;
       margin-right: 0.75rem;
-      padding: 0.5rem 1rem;
+      padding: 0.5rem 0.75rem;
       border-radius: var(--border-radius);
       align-items: center;
 

--- a/src/components/RemindItem/WritableRemindItem/index.scss
+++ b/src/components/RemindItem/WritableRemindItem/index.scss
@@ -87,13 +87,3 @@
     }
   }
 }
-
-@media (max-width: 750px) {
-  .remind-item {
-    &__header {
-      &__button-text {
-        display: none;
-      }
-    }
-  }
-}

--- a/src/hooks/apis/useDeletePlanMutation.ts
+++ b/src/hooks/apis/useDeletePlanMutation.ts
@@ -1,4 +1,5 @@
 import { deletePlan } from '@/apis/client/deletePlan';
+import { ajajaToast } from '@/components/Toaster/customToast';
 import { QUERY_KEY } from '@/constants/queryKey';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -11,6 +12,7 @@ export const useDeletePlanMutation = () => {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEY.MY_PLANS],
       });
+      ajajaToast.success('계획 삭제 완료');
     },
     throwOnError: true,
   });

--- a/src/hooks/apis/useEditPlanMutation.ts
+++ b/src/hooks/apis/useEditPlanMutation.ts
@@ -1,4 +1,5 @@
 import { editPlan } from '@/apis/client/editPlan';
+import { ajajaToast } from '@/components/Toaster/customToast';
 import { QUERY_KEY } from '@/constants/queryKey';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -16,6 +17,7 @@ export const useEditPlanMutation = (planId: number) => {
           queryKey: [QUERY_KEY.MY_PLANS],
         }),
       ]);
+      ajajaToast.success('계획 수정 완료');
     },
     throwOnError: true,
   });

--- a/src/hooks/apis/usePostNewPlanMutation.ts
+++ b/src/hooks/apis/usePostNewPlanMutation.ts
@@ -1,4 +1,5 @@
 import { postNewPlan } from '@/apis/client/postNewPlan';
+import { ajajaToast } from '@/components/Toaster/customToast';
 import { QUERY_KEY } from '@/constants/queryKey';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -11,6 +12,7 @@ export const usePostNewPlanMutation = () => {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEY.MY_PLANS],
       });
+      ajajaToast.success('계획 생성 완료');
     },
   });
 };


### PR DESCRIPTION
## 📌 이슈 번호

close #208 

## 🚀 구현 내용
- [ ] 계획 제목, 내용 입력가능할 때 vs 불가능할 때 디자인 차이 두기
- [ ] 클릭가능한 요소 cursor pointer로 설정
- [ ] 리마인드 아이템 작성 시 경고문구 크기 증가 및 작성하기/수정하기 텍스트 삭제
- [ ] 동일한 리마인드 메세지 체크 시, 항상 동기화 되도록 로직 수정
- [ ] 리마인드 옵션 text 사이 margin 제거
- [ ] 확정버튼 text 내용 변경 및 수정 페이지 리마인드 알림 여부 text 크기 증가
- [ ] 작성, 수정, 상세 페이지 전체 height 100% 설정
- [ ] 계획 작성, 수정, 삭제 토스트 적용


<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
