### PR TITLE
[민우] - 디자인 수정

### DIFF
--- a/src/app/(header)/create/index.scss
+++ b/src/app/(header)/create/index.scss
@@ -1,5 +1,5 @@
 .create-page {
-  padding: 1.75rem 2.5rem;
+  padding: 3rem 5rem;
   height: 100%;
   display: flex;
   flex-direction: column;

--- a/src/app/(header)/edit/[planId]/index.scss
+++ b/src/app/(header)/edit/[planId]/index.scss
@@ -1,5 +1,5 @@
 .edit-page {
-  padding: 1.75rem 2.5rem;
+  padding: 3rem 5rem;
   height: 100%;
   display: flex;
   flex-direction: column;

--- a/src/app/(header)/plans/[planId]/index.scss
+++ b/src/app/(header)/plans/[planId]/index.scss
@@ -1,5 +1,5 @@
 .plans-page {
-  padding: 1.75rem 2.5rem;
+  padding: 3rem 5rem;
   height: 100%;
   display: flex;
   flex-direction: column;

--- a/src/components/Dropdown/index.scss
+++ b/src/components/Dropdown/index.scss
@@ -74,7 +74,9 @@
     }
   }
 
-
+  &--remind{
+    width: 7rem;
+  }
 }
 
 #dropdown:checked + label + div {

--- a/src/components/PlanInput/PlanInput.tsx
+++ b/src/components/PlanInput/PlanInput.tsx
@@ -13,7 +13,7 @@ interface PlanInputProps {
   placeholder: string;
   maxLength: number;
   editable?: boolean;
-  nextTextAreaRef: RefObject<HTMLTextAreaElement>;
+  nextTextAreaRef?: RefObject<HTMLTextAreaElement>;
 }
 
 export default function PlanInput({
@@ -33,7 +33,7 @@ export default function PlanInput({
 
   // Enter 키를 눌렀을 때 호출되는 함수
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (kind === 'title' && event.key === 'Enter') {
+    if (nextTextAreaRef && kind === 'title' && event.key === 'Enter') {
       event.preventDefault();
       if (nextTextAreaRef.current) {
         nextTextAreaRef.current.focus();

--- a/src/components/PlanInput/PlanInput.tsx
+++ b/src/components/PlanInput/PlanInput.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import classNames from 'classnames';
-import React, { ChangeEvent } from 'react';
+import React, { ChangeEvent, KeyboardEvent, RefObject } from 'react';
 import './index.scss';
 
 type kindType = 'title' | 'content';
@@ -13,6 +13,7 @@ interface PlanInputProps {
   placeholder: string;
   maxLength: number;
   editable?: boolean;
+  nextTextAreaRef: RefObject<HTMLTextAreaElement>;
 }
 
 export default function PlanInput({
@@ -22,6 +23,7 @@ export default function PlanInput({
   placeholder,
   maxLength,
   editable = false,
+  nextTextAreaRef,
 }: PlanInputProps) {
   const handleChangeInput = (event: ChangeEvent<HTMLTextAreaElement>) => {
     if (event.target.value.length <= maxLength) {
@@ -29,14 +31,26 @@ export default function PlanInput({
     }
   };
 
+  // Enter 키를 눌렀을 때 호출되는 함수
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (kind === 'title' && event.key === 'Enter') {
+      event.preventDefault();
+      if (nextTextAreaRef.current) {
+        nextTextAreaRef.current.focus();
+      }
+    }
+  };
+
   return (
     <div className="planInput--container">
       <textarea
         id="planInput"
+        ref={kind === 'content' ? nextTextAreaRef : null}
         readOnly={!editable}
         disabled={!editable}
         value={textInput}
         onChange={handleChangeInput}
+        onKeyDown={handleKeyDown}
         placeholder={placeholder}
         className={classNames(
           'planInput',

--- a/src/components/Remind/ReadOnlyRemind/ReadOnlyRemind.tsx
+++ b/src/components/Remind/ReadOnlyRemind/ReadOnlyRemind.tsx
@@ -46,7 +46,6 @@ export default function ReadOnlyRemind({ planId }: ReadOnlyRemindProps) {
 
   const handleToggleIsRemindable = () => {
     toggleIsRemindableAPI(parseInt(planId, 10));
-    console.log(`${planId}에 대한 리마인드 알림 여부 toggle API호출 `);
   };
 
   return (

--- a/src/components/Remind/WritableRemind/WritableRemind.tsx
+++ b/src/components/Remind/WritableRemind/WritableRemind.tsx
@@ -120,7 +120,10 @@ export default function WritableRemind({
             setSelectedValue={(newSelectedValue: number) => {
               setRemindOption('TotalPeriod', newSelectedValue);
             }}
-            classNameList={['writable-remind__options__dropdown']}
+            classNameList={[
+              'writable-remind__options__dropdown',
+              'dropdown--remind',
+            ]}
           />
           <span className={classNames('writable-remind__options__text')}>
             동안
@@ -132,7 +135,10 @@ export default function WritableRemind({
             setSelectedValue={(newSelectedValue: number) => {
               setRemindOption('Term', newSelectedValue);
             }}
-            classNameList={['writable-remind__options__dropdown']}
+            classNameList={[
+              'writable-remind__options__dropdown',
+              'dropdown--remind',
+            ]}
           />
           <span className={classNames('writable-remind__options__text')}>
             마다 매달
@@ -144,7 +150,10 @@ export default function WritableRemind({
             setSelectedValue={(newSelectedValue: number) => {
               setRemindOption('Date', newSelectedValue);
             }}
-            classNameList={['writable-remind__options__dropdown']}
+            classNameList={[
+              'writable-remind__options__dropdown',
+              'dropdown--remind',
+            ]}
           />
           <Dropdown
             dropdownId="remindTimeDropdown"
@@ -153,7 +162,10 @@ export default function WritableRemind({
             setSelectedValue={(newSelectedValue: number) => {
               setRemindOption('Time', newSelectedValue);
             }}
-            classNameList={['writable-remind__options__dropdown']}
+            classNameList={[
+              'writable-remind__options__dropdown',
+              'dropdown--remind',
+            ]}
           />
           <span className={classNames('writable-remind__options__text')}>
             에 리마인드를 받을래요 !

--- a/src/components/RemindItem/ReadOnlyRemindItem/ReadOnlyRemindItem.tsx
+++ b/src/components/RemindItem/ReadOnlyRemindItem/ReadOnlyRemindItem.tsx
@@ -143,7 +143,7 @@ export default function ReadOnlyRemindItem({
           <ModalEvaluate
             onClickFinish={handleClickModalFinish}
             onClickExit={handleClickModalExit}>
-            {`${remindMonth}월 ${remindDate}까지 계획을 얼마나 잘 이행했나요 ? `}
+            {`${remindMonth}월 ${remindDate}일까지 계획을 얼마나 잘 이행했나요 ? `}
           </ModalEvaluate>
         </Modal>
       )}

--- a/src/components/RemindItem/ReadOnlyRemindItem/index.scss
+++ b/src/components/RemindItem/ReadOnlyRemindItem/index.scss
@@ -19,13 +19,14 @@
     display: flex;
     position: absolute;
     left: 1rem;
-    padding: 0.25rem 0.5rem;
+    padding: 0.3rem 0.75rem;
     border-radius: var(--border-radius);
+    align-items: center;
 
     &__text {
       margin-left: 0.25rem;
-      font-size: 0.6rem;
-      line-height: 0.7rem;
+      font-size: 0.8rem;
+      line-height: 0.8rem;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;

--- a/src/components/RemindItem/WritableRemindItem/index.scss
+++ b/src/components/RemindItem/WritableRemindItem/index.scss
@@ -31,14 +31,14 @@
       transition: all 1s ease;
       display: flex;
       margin-right: 0.75rem;
-      padding: 0.5rem 0.75rem;
+      padding: 0.3rem 0.75rem;
       border-radius: var(--border-radius);
       align-items: center;
 
       &__text {
         margin-left: 0.25rem;
         font-size: 0.8rem;
-        line-height: 0.7rem;
+        line-height: 0.8rem;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;

--- a/src/components/WritablePlan/WritablePlan.tsx
+++ b/src/components/WritablePlan/WritablePlan.tsx
@@ -1,5 +1,5 @@
 import { Color } from '@/types';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import {
   AjajaButton,
   Icon,
@@ -65,6 +65,9 @@ export default function WritablePlan({
     changeTags(newTagList);
     setInputValue('');
   };
+
+  const nextTextAreaRef = useRef<HTMLTextAreaElement>(null);
+
   return (
     <div className="plan__container">
       <div className="plan__header">
@@ -91,18 +94,20 @@ export default function WritablePlan({
         <PlanInput
           editable={true}
           kind="title"
-          placeholder="어떤 계획을 가지고 계신가요?"
+          placeholder="어떤 계획을 가지고 계신가요? (최대 20자)"
           onChangeInput={onChangeTitle}
-          maxLength={40}
+          maxLength={20}
           textInput={title}
+          nextTextAreaRef={nextTextAreaRef}
         />
         <PlanInput
           editable={true}
           kind="content"
-          placeholder="계획에 대해서 자세히 설명해주세요!"
+          placeholder="계획에 대해서 자세히 설명해주세요! (최대 300자)"
           onChangeInput={onChangeDescription}
           maxLength={250}
           textInput={description}
+          nextTextAreaRef={nextTextAreaRef}
         />
         <div>
           <InputTag


### PR DESCRIPTION
## 📌 이슈 번호

close #224

## 🚀 구현 내용
- [x]  계획 제목창 엔터 입력 시 줄바꿈 말고 다음으로 이동하도록 f1fcfcfec5afbae98503e1a4c1e5dd8a81b45eb1
- [x]  제목, 내용 글자 수 제한 placeHolder ⇒ ex) `계획 제목을 입력해주세요(최대 20자)`  f1fcfcfec5afbae98503e1a4c1e5dd8a81b45eb1
- [x]  드롭다운 width 리마인드 쪽에서는 줄이기 6ba24d0acf5d1fddef9a6d02c38c139371b1cf5d
- [x]  작성, 상세, 수정 페이지 전체 패딩 수정 97052406746f381ef806f6fcc47533370445b367
- [x]  readOnlyRemind에서 피드백 모달에 전달해주는 text 수정 09840ab38b32fb2c2a21840ac3cfb69af0be1a5b
- [x] 리마인드 미작성 경고문구 line-height 및 padding 수정 d77f134b7d037d23226032defcbec5da3fed4cfa

<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
