### PR TITLE
[민우] - Icon 컴포넌트 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
       <head>
         <link
           rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
+          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
         />
       </head>
       <body

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -54,7 +54,7 @@ export default function Icon({
     <span
       className={classNames(
         'icon',
-        'material-symbols-outlined',
+        'material-symbols-rounded',
         `font-size-${size}`,
         `color-origin-${color}`,
         { 'icon--isFilled': isFilled },

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -3,15 +3,18 @@ import classNames from 'classnames';
 import './index.scss';
 
 const ICON_NAME_MAP = {
-  CREATE_NEW_PLAN: 'add',
+  PLUS: 'add',
+  CREATE_NEW_PLAN: 'stylus',
+  FEEDBACK: 'edit_note',
+  OTHER_PLAN: 'explore',
+  HOME: 'home',
+  PROFILE: 'account_circle',
   NOTIFICATION_ON: 'notifications',
   NOTIFICATION_OFF: 'notifications_off',
   PLAN_OPEN: 'lock_open',
   PLAN_CLOSE: 'lock',
   ITEM_OPEN: 'expand_more',
   ITEM_CLOSE: 'expand_less',
-  OTHER_PLAN: 'calendar_today',
-  PROFILE: 'person',
   ERROR: 'error',
   WARNING: 'warning',
   AJAJA: 'local_fire_department',

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -36,6 +36,7 @@ const ICON_NAME_MAP = {
   STAR: 'star',
   FAVORITE: 'favorite',
   ARROW_UP: 'arrow_upward',
+  COPY: 'content_copy',
 };
 
 interface IconProps {

--- a/src/styles/class/font-size.scss
+++ b/src/styles/class/font-size.scss
@@ -12,7 +12,7 @@
 
 @mixin icon-common($font) {
   @each $key, $value in $font {
-    .material-symbols-outlined.font-size {
+    .material-symbols-rounded.font-size {
       &-#{$key} {
         font-size: $value;
       }

--- a/src/types/IconName.ts
+++ b/src/types/IconName.ts
@@ -31,4 +31,5 @@ export type IconName =
   | 'TROPHY'
   | 'STAR'
   | 'FAVORITE'
-  | 'ARROW_UP';
+  | 'ARROW_UP'
+  | 'COPY';

--- a/src/types/IconName.ts
+++ b/src/types/IconName.ts
@@ -1,13 +1,16 @@
 export type IconName =
-  | 'CREATE_NEW_PLAN'
+  | 'PLUS' // 내 계획 페이지 + 버튼
+  | 'CREATE_NEW_PLAN' // 계획 작성
+  | 'FEEDBACK' // 피드백
+  | 'OTHER_PLAN' // 다른 계획 둘러보기
+  | 'HOME' // 홈
+  | 'PROFILE' // 마이 페이지
   | 'NOTIFICATION_ON'
   | 'NOTIFICATION_OFF'
   | 'PLAN_OPEN'
   | 'PLAN_CLOSE'
   | 'ITEM_OPEN'
   | 'ITEM_CLOSE'
-  | 'OTHER_PLAN'
-  | 'PROFILE'
   | 'WARNING'
   | 'ERROR'
   | 'AJAJA'


### PR DESCRIPTION
## 📌 이슈 번호

close #247 

## 🚀 구현 내용
- [x] googleIcon 기본 style outlined -> rounded로 수정 dca3da930c6d7b41f282c18558cea90671f0088c
- [x] 추가로 사용되는 icon name 추가 17eaa0b5de3dbbdab5be11e307114c51feb46c0c
``` ts
export type IconName =
  | 'PLUS' // 내 계획 페이지 + 버튼
  | 'CREATE_NEW_PLAN' // 계획 작성
  | 'FEEDBACK' // 피드백
  | 'OTHER_PLAN' // 다른 계획 둘러보기
  | 'HOME' // 홈
  | 'PROFILE' // 마이 페이지
  | 'COPY'  // 링크 복사 아이콘
```


<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
