### PR TITLE
[민우] - Dropdown 컴포넌트 수정

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -60,7 +60,7 @@ export default function Dropdown({
       (option) => option.value === selectedValue,
     );
 
-    return selectedOption ? selectedOption.name : undefined;
+    return selectedOption?.name;
   };
 
   return (

--- a/src/components/Dropdown/index.scss
+++ b/src/components/Dropdown/index.scss
@@ -54,9 +54,15 @@
       border-top: none;
       list-style-type: none;
       text-align: center;
-      max-height: 12rem;
-      overflow-y: auto;
+      max-height: 9rem;
       border-radius: 0px 0px var(--border-radius) var(--border-radius);
+
+      overflow-y: auto;
+      -ms-overflow-style: none;
+      scrollbar-width: none;
+      &::-webkit-scrollbar {
+        display: none;
+      }
     }
 
     &__item {
@@ -73,9 +79,5 @@
         background-color: var(--origin-primary);
       }
     }
-  }
-
-  &--remind {
-    width: 7rem;
   }
 }

--- a/src/components/Dropdown/index.scss
+++ b/src/components/Dropdown/index.scss
@@ -1,6 +1,6 @@
 .dropdown {
   &__container {
-    width: 10rem;
+    display: inline-block;
     position: relative;
     z-index: 10;
     background-color: transparent;
@@ -24,8 +24,8 @@
     justify-content: center;
     align-items: center;
     position: relative;
-    padding: 0.5rem 0.75rem;
-    border: var(--border-width) solid var(--origin-primary);
+    padding: 0.5rem 2rem;
+    border: 1px solid var(--origin-primary);
     border-radius: var(--border-radius);
     cursor: pointer;
 
@@ -37,7 +37,7 @@
 
     &__icon {
       position: absolute;
-      right: 0.2rem;
+      right: 0rem;
     }
   }
 
@@ -50,7 +50,7 @@
     border-radius: 0px 0px var(--border-radius) var(--border-radius);
 
     &__list {
-      border: var(--border-width) solid var(--origin-primary);
+      border: 1px solid var(--origin-primary);
       border-top: none;
       list-style-type: none;
       text-align: center;
@@ -61,11 +61,12 @@
 
     &__item {
       padding: 0.5rem;
-
+      border-bottom: 1px solid var(--origin-primary);
       cursor: pointer;
 
       &:last-child {
         border-radius: 0px 0px 9px 9px;
+        border-bottom: none;
       }
 
       &:hover {
@@ -74,11 +75,7 @@
     }
   }
 
-  &--remind{
+  &--remind {
     width: 7rem;
   }
-}
-
-#dropdown:checked + label + div {
-  display: block;
 }


### PR DESCRIPTION
## 📌 이슈 번호

close #247

## 🚀 구현 내용
- [ ] dropdown 컴포넌트 padding 및 width 글자수에 따라 반응형으로 늘어나도록 변경 c929097392732fd442be4f5cdbbb129378c0eb0b
- [ ] dropdown 컴포넌트 overflow 시 스크롤 안 보이도록 수정 9ef337091373181131ee2c07a5f5425120d9fbaf

<img width="169" alt="image" src="https://github.com/New-Barams/this-year-ajaja-fe/assets/31370590/7162b93f-feeb-41a5-a954-294ab718656d">

https://github.com/New-Barams/this-year-ajaja-fe/assets/31370590/1f4c6e3a-4462-4f07-ae00-8bcd14d5e31a


## 📘 참고 사항
현재 dropdown 내 옵션이 많아 스크롤 되는 경우는 리마인드 날짜(1일, 2일, 3일 ... 31일) 선택하는 경우인데, 이 경우 스크롤이 생기면 아래처럼 hover 효과나 가운데 정렬이 이쁘지 않아 지금처럼 scrollbar 안보이도록 처리해주었습니다 ! 

<img width="170" alt="image" src="https://github.com/New-Barams/this-year-ajaja-fe/assets/31370590/a97739aa-5b80-492c-92ac-f55b61472e89">


<!--## ❓ 궁금한 내용-->
