### PR TITLE
[노철] - 공용 컴포넌트 변경

### DIFF
--- a/src/components/IconSwitchButton/IconSwitchButton.tsx
+++ b/src/components/IconSwitchButton/IconSwitchButton.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Icon, SwitchButton } from '@/components';
+import { useState } from 'react';
 import './index.scss';
 
 type OnIconName = 'NOTIFICATION_ON' | 'PLAN_OPEN';
@@ -17,14 +18,27 @@ export default function IconSwitchButton({
   onClick,
   isActive = false,
 }: IconSwitchButtonProps) {
+  const [isOn, setIsOn] = useState<boolean>(isActive);
+  const handleClick = () => {
+    setIsOn(!isOn);
+    onClick();
+  };
   return (
-    <SwitchButton onClick={onClick} isOn={isActive}>
+    <SwitchButton onClick={handleClick} isOn={isOn}>
       <div className="icon__wrapper">
         <div>
-          <Icon name={offIconName} color="gray-300" />
+          <Icon
+            name={offIconName}
+            color={isOn ? 'white-100' : 'primary'}
+            size="sm"
+          />
         </div>
         <div>
-          <Icon name={onIconName} color="gray-300" />
+          <Icon
+            name={onIconName}
+            color={isOn ? 'primary' : 'white-100'}
+            size="sm"
+          />
         </div>
       </div>
     </SwitchButton>

--- a/src/components/IconSwitchButton/index.scss
+++ b/src/components/IconSwitchButton/index.scss
@@ -4,7 +4,8 @@
   display: flex;
   align-items: center;
   height: 100%;
-  justify-content: space-evenly;
+  padding: 0 0.35rem;
+  justify-content: space-between;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;

--- a/src/components/InputTag/InputTag.tsx
+++ b/src/components/InputTag/InputTag.tsx
@@ -13,7 +13,8 @@ export default function InputTag({ onSubmit, ...props }: InputTagProps) {
     if (input && input.current) {
       const inputValue = input.current.value;
       if (inputValue.trim()) {
-        onSubmit(input.current.value);
+        onSubmit(inputValue);
+        input.current.value = '';
       }
     }
   };

--- a/src/components/InputTag/InputTag.tsx
+++ b/src/components/InputTag/InputTag.tsx
@@ -1,41 +1,32 @@
 'use client';
 
-import { FormEvent } from 'react';
-import { Tag } from '..';
+import { FormEvent, useRef } from 'react';
 import './index.scss';
 
 interface InputTagProps {
-  style?: React.CSSProperties;
-  inputValue: string;
-  onSubmit: () => void;
-  onChange: (changeValue: string) => void;
+  onSubmit: (inputValue: string) => void;
 }
-export default function InputTag({
-  style,
-  onChange,
-  inputValue,
-  onSubmit,
-  ...props
-}: InputTagProps) {
-  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    onChange(event.target.value);
-  };
+export default function InputTag({ onSubmit, ...props }: InputTagProps) {
+  const input = useRef<null | HTMLInputElement>(null);
   const handleInputSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    onSubmit();
+    if (input && input.current) {
+      const inputValue = input.current.value;
+      if (inputValue.trim()) {
+        onSubmit(input.current.value);
+      }
+    }
   };
   return (
-    <Tag color="orange-200" style={style} {...props}>
-      <form className="inputTag" onSubmit={handleInputSubmit}>
-        <input
-          className="inputTag__tag font-size-base"
-          type="text"
-          placeholder="태그 입력(최대10글자)"
-          value={inputValue}
-          onChange={handleInputChange}
-          maxLength={10}
-        />
-      </form>
-    </Tag>
+    <form className="inputTag" onSubmit={handleInputSubmit}>
+      <input
+        ref={input}
+        className="inputTag__input font-size-sm"
+        type="text"
+        placeholder="태그를 입력해 주세요"
+        maxLength={10}
+        {...props}
+      />
+    </form>
   );
 }

--- a/src/components/InputTag/InputTag.tsx
+++ b/src/components/InputTag/InputTag.tsx
@@ -6,16 +6,13 @@ import './index.scss';
 interface InputTagProps {
   onSubmit: (inputValue: string) => void;
 }
-export default function InputTag({ onSubmit, ...props }: InputTagProps) {
+export default function InputTag({ onSubmit }: InputTagProps) {
   const input = useRef<null | HTMLInputElement>(null);
   const handleInputSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (input && input.current) {
-      const inputValue = input.current.value;
-      if (inputValue.trim()) {
-        onSubmit(inputValue);
-        input.current.value = '';
-      }
+      onSubmit(input.current.value);
+      input.current.value = '';
     }
   };
   return (
@@ -26,7 +23,6 @@ export default function InputTag({ onSubmit, ...props }: InputTagProps) {
         type="text"
         placeholder="태그를 입력해 주세요"
         maxLength={10}
-        {...props}
       />
     </form>
   );

--- a/src/components/InputTag/index.scss
+++ b/src/components/InputTag/index.scss
@@ -1,39 +1,32 @@
 .inputTag {
-  height: 1rem;
-
+  position: relative;
   &:focus-within {
     &::after {
-      content: '엔터 입력시 태그를 등록 할 수 있고 등록된 태그는 클릭시 삭제됩니다.\A태그는 최대 5개까지 추가 할 수 있습니다.';
+      margin-top: 0.5rem;
+      content: '엔터 입력시 태그를 등록 할 수 있습니다.\A등록된 태그는 클릭시 삭제됩니다.\A태그는 최대 10글자, 5개까지 추가 할 수 있습니다.';
       position: absolute;
       color: var(--origin-white-200);
       white-space: pre;
       background-color: var(--origin-gray-200);
       line-height: 1.5rem;
       left: 0;
-      top: 1.5rem;
-      margin-top: 1rem;
       display: block;
       border-radius: var(--border-radius);
-      padding: 0.5rem 1rem;
+      padding: 0.25rem 0.875rem;
       z-index: 1;
     }
   }
-  &__tag {
-    padding: 0;
-    margin: 0;
+  &__input {
+    padding: 0.25rem 0.875rem;
     line-height: 1rem;
-    background-color: inherit;
+    vertical-align: middle;
+    margin: 0;
     width: 10rem;
-    border: none;
     display: inline-block;
-    height: 1rem;
-
+    border: 1px solid var(--origin-primary);
+    border-radius: var(--border-radius);
     &::placeholder {
-      font-size: 1rem;
-      line-height: 1rem;
-      height: 1rem;
-      overflow: visible;
-      vertical-align: top;
+      font-size: var(font-size-sm);
     }
     &:focus {
       outline: none;

--- a/src/components/InputTag/index.scss
+++ b/src/components/InputTag/index.scss
@@ -18,7 +18,7 @@
   }
   &__input {
     padding: 0.25rem 0.875rem;
-    line-height: 1rem;
+
     vertical-align: middle;
     margin: 0;
     width: 10rem;

--- a/src/components/SwitchButton/index.scss
+++ b/src/components/SwitchButton/index.scss
@@ -16,6 +16,8 @@
 .slider {
   position: absolute;
   cursor: pointer;
+  width: 50px;
+  height: 1.5rem;
   top: 0;
   left: 0;
   right: 0;
@@ -28,24 +30,24 @@
 .slider:before {
   position: absolute;
   content: '';
-  height: 1.5rem;
-  width: 1.5rem;
-  left: 0.25rem;
-  bottom: calc(50% - 0.75rem);
+  height: 1.25rem;
+  width: 1.25rem;
+  left: 2.5px;
+  bottom: calc(50% - 1.25rem / 2);
+
   background-color: white;
   -webkit-transition: 0.4s;
   transition: 0.4s;
-  box-shadow: var(--origin-shadow);
 }
 
 input:checked + .slider {
-  background-color: var(--origin-orange-200);
+  background-color: var(--origin-primary);
 }
 
 input:checked + .slider:before {
-  -webkit-transform: translateX(1.75rem);
-  -ms-transform: translateX(1.75rem);
-  transform: translateX(1.75rem);
+  -webkit-transform: translateX(25px);
+  -ms-transform: translateX(25px);
+  transform: translateX(25px);
 }
 
 /* Rounded sliders */

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,37 +1,27 @@
-import { Color } from '@/types';
 import classNames from 'classnames';
+import React from 'react';
 import './index.scss';
 
-interface TagProps {
-  color?: Color;
-  style?: React.CSSProperties;
+interface TagProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   classNameList?: string[];
-  onClick?: (event?: React.MouseEvent) => void;
 }
 
 export default function Tag({
   children,
-  color = 'primary',
-  style,
   classNameList = [],
-  onClick,
   ...props
 }: TagProps) {
   return (
     <div
       className={classNames(
         `tag`,
-        `background-origin-${color}`,
-        {
-          pointer: onClick,
-        },
+        'font-size-sm',
         classNameList,
+        props.onClick ? 'pointer' : '',
       )}
-      style={{ ...style }}
-      onClick={onClick}
       {...props}>
-      {children}
+      #{children}
     </div>
   );
 }

--- a/src/components/Tag/index.scss
+++ b/src/components/Tag/index.scss
@@ -1,13 +1,6 @@
 .tag {
   cursor: default;
   display: inline-block;
-  font-size: var(--font-xs);
-  color: white;
-  padding: 0.5rem 1rem;
-  border-radius: 1.5rem;
-  margin: 0.25rem;
-  position: relative;
-  overflow: visible;
   &.pointer {
     cursor: pointer;
   }


### PR DESCRIPTION
## 📌 이슈 번호

close #246 

## 🚀 구현 내용
- Tag 컴포넌트 스타일 변경 및 props 변경
```tsx
interface TagProps extends React.HTMLAttributes<HTMLDivElement>{
  children: React.ReactNode; // 태그 내용
  classNameList?: string[];
}

<Tag >태그 내용</Tag>
<Tag onClick={handleOnClick}>태그내용</Tag>
```

- InputTag 컴포넌트 스타일 변경
```tsx
interface InputTagProps {
  onSubmit: (submitValue: string) => void; //태그 생성을 위한 submit함수
}

<InputTag
	onSubmit={(value: string) => {console.log(value)}}
/>

```
- SwitchButton 크기 고정 및 IconSwitchButton 아이콘 스타일 변경 
```tsx
interface IconSwitchButtonProps {
  onIconName: OnIconName; // 우측에 위치할 아이콘이름
  offIconName: OffIconName; //좌측에 위치할 아이콘이름
  onClick: () => void; // 연결할 함수 
  isActive: boolean; // 초기값, default = false
}
// 현재 아이콘은 NOTIFICATION, PLAN만 가능 
<IconSwitchButton
        onIconName="NOTIFICATION_ON"
        offIconName="NOTIFICATION_OFF"
        isActive={false}
        onClick={() => {}}
      />

```
![올해도-아좌좌-프로필-1-Microsoft_-Edge-2023-12-14-23-11-14 (1)](https://github.com/New-Barams/this-year-ajaja-fe/assets/61609327/f6f77643-169d-4a2f-a91a-9090574f1899)

<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
