### PR TITLE
[혜수] - 외부 레이아웃 디자인 변경(위치만 잡아놓기) 

### DIFF
--- a/src/app/(headerless)/login/index.scss
+++ b/src/app/(headerless)/login/index.scss
@@ -1,8 +1,8 @@
 @import '@styles/variables.scss';
 
 .wrapper {
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -1,0 +1,48 @@
+$media-majinot-width: 1230px;
+$media-middle-width: 1500px;
+
+.global {
+  &-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100vw;
+    height: 100vh;
+    gap: 10%;
+  }
+  &-landing {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 10%;
+    width: 520px;
+    margin: auto;
+    @media screen and (max-width: $media-majinot-width) {
+      display: none;
+    }
+    @media screen and (min-width: $media-middle-width) {
+      left: 15%;
+    }
+  }
+  &-frame {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 450px;
+    margin: auto;
+    @media screen and (min-width: $media-majinot-width) {
+      right: 10%;
+      height: 90%;
+      border: 1rem solid var(--origin-secondary);
+      overflow: hidden;
+      border-radius: calc(var(--border-radius) * 2);
+    }
+    @media screen and (max-width: $media-majinot-width) {
+      left: 0;
+      right: 0;
+    }
+    @media screen and (min-width: $media-middle-width) {
+      right: 15%;
+    }
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,14 +1,15 @@
 import Provider from '@/provider/Provider';
 import classNames from 'classnames';
 import type { Metadata } from 'next';
-import { Noto_Sans_KR } from 'next/font/google';
+import { Poor_Story } from 'next/font/google';
 import '@styles/reset.scss';
 import '@styles/variables.scss';
 import '@styles/webkit.scss';
+import './index.scss';
 
-const noto_sans = Noto_Sans_KR({
+const poor_story = Poor_Story({
   subsets: ['latin'],
-  weight: ['100', '400', '700', '900'],
+  weight: ['400'],
 });
 
 export const metadata: Metadata = {
@@ -32,12 +33,20 @@ export default function RootLayout({
           href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
         />
       </head>
-      <body
-        className={classNames(
-          noto_sans.className,
-          'background-origin-white-200',
-        )}>
-        <Provider>{children}</Provider>
+      <body className={classNames(poor_story.className, 'background-origin')}>
+        <Provider>
+          <div
+            className={classNames('border-origin-text-100', 'global-landing')}>
+            랜딩 설명입니다.
+          </div>
+          <div
+            className={classNames(
+              'background-origin-background',
+              'global-frame',
+            )}>
+            {children}
+          </div>
+        </Provider>
       </body>
     </html>
   );

--- a/src/styles/origin-theme.scss
+++ b/src/styles/origin-theme.scss
@@ -1,5 +1,10 @@
 :root {
   --origin-primary: #f76c5e;
+  --origin-secondary: #bbb8b8;
+  --origin-background: #ffffff;
+  --origin-text-100: #000000;
+  --origin-text-300: #5e5f60;
+  --origin-text-600: #ffffff;
 
   --origin-white-100: #ffffff;
   --origin-white-200: #fffef9;

--- a/src/styles/standard.scss
+++ b/src/styles/standard.scss
@@ -1,4 +1,4 @@
 :root {
   --border-radius: 12px;
-  --border-width: 2px;
+  --border-width: 1px;
 }

--- a/src/styles/themes.scss
+++ b/src/styles/themes.scss
@@ -1,6 +1,11 @@
 $themes: (
   origin: (
     primary: var(--origin-primary),
+    secondary: var(--origin-secondary),
+    background: var(--origin-background),
+    text-100: var(--origin-text-100),
+    text-300: var(--origin-text-300),
+    text-600: var(--origin-text-600),
     white-100: var(--origin-white-100),
     white-200: var(--origin-white-200),
     white-300: var(--origin-white-300),


### PR DESCRIPTION
## 📌 이슈 번호

close #244 

## 🚀 구현 내용
- 외부 레이아웃 디자인 추가
- 반응형 구현
- 로그인 페이지만 적용해놨습니다.
## 📘 참고 사항
기존 페이지에 width: 100% height:100%로 하면 적용 될 것 같습니다.
<!--## ❓ 궁금한 내용-->

https://github.com/New-Barams/this-year-ajaja-fe/assets/67812466/77d1d659-b512-401b-a49e-194ff0404058

