### PR TITLE
[노철] - 토큰 갱신 로직 추가

### DIFF
--- a/src/apis/axiosInstanceClient.ts
+++ b/src/apis/axiosInstanceClient.ts
@@ -41,6 +41,7 @@ axiosInstanceClient.interceptors.response.use(
     return response;
   },
   async (error: AxiosError<ErrorResponseData>) => {
+    //TODO:에러네임, 쿠키 키 상수화
     if (
       error.response &&
       error.response.data &&
@@ -70,7 +71,7 @@ axiosInstanceClient.interceptors.response.use(
             accessToken,
             refreshToken,
           });
-          console.log(tokens, '토큰 교체');
+
           setCookie('auth', tokens, { maxAge: 604800 });
           if (error.config) {
             error.config.headers.Authorization = `Bearer ${tokens.accessToken}`;

--- a/src/apis/axiosInstanceClient.ts
+++ b/src/apis/axiosInstanceClient.ts
@@ -1,8 +1,11 @@
 'use client';
 
 import { NETWORK } from '@/constants/api';
+import { ErrorResponseData } from '@/types/apis/ErrorResponseData';
+import { checkTokenExp } from '@/utils/checkTokenExp';
 import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
-import { getCookie } from 'cookies-next';
+import { getCookie, setCookie } from 'cookies-next';
+import { postReissue } from '@apis/client/postReissue';
 
 export const axiosInstanceClient = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
@@ -25,9 +28,65 @@ axiosInstanceClient.interceptors.request.use(
       throw new Error('Client Component: 토큰이 존재하지 않습니다');
     }
     config.headers.Authorization = `Bearer ${JSON.parse(auth).accessToken}`;
+
     return config;
   },
   (error: AxiosError) => {
     return Promise.reject(error);
   },
 );
+
+axiosInstanceClient.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  async (error: AxiosError<ErrorResponseData>) => {
+    if (
+      error.response &&
+      error.response.data &&
+      error.response.data.errorName === 'INVALID_SIGNATURE'
+    ) {
+      alertAndLogin();
+    }
+
+    if (
+      error.response &&
+      error.response.data &&
+      error.response.data?.errorName === 'EXPIRED_TOKEN'
+    ) {
+      const auth = getCookie('auth');
+      if (auth) {
+        const accessToken = JSON.parse(auth).accessToken;
+        const refreshToken = JSON.parse(auth).refreshToken;
+
+        const isExpiredAccessToken = !checkTokenExp(accessToken);
+        const isExpiredRefreshToken = !checkTokenExp(refreshToken);
+
+        if (isExpiredAccessToken || isExpiredRefreshToken) {
+          //TODO: 토큰 재발행에 실패한다면 ?
+          const {
+            data: { data: tokens },
+          } = await postReissue({
+            accessToken,
+            refreshToken,
+          });
+          console.log(tokens, '토큰 교체');
+          setCookie('auth', tokens, { maxAge: 604800 });
+          if (error.config) {
+            error.config.headers.Authorization = `Bearer ${tokens.accessToken}`;
+            //TODO 그래도 retry에 실패 한다면 ?
+            return axiosInstanceClient.request(error.config);
+          }
+        }
+        alertAndLogin();
+      }
+    }
+
+    return error;
+  },
+);
+
+const alertAndLogin = () => {
+  alert('로그인 정보가 유효하지 않습니다. 다시 로그인해주세요 ');
+  window.location.replace(`${process.env.NEXT_PUBLIC_REDIRECT_URL}?way=logout`);
+};

--- a/src/apis/client/postReissue.ts
+++ b/src/apis/client/postReissue.ts
@@ -1,0 +1,30 @@
+import { auth } from '@/stores/authStore';
+import { axiosInstanceClient } from '@apis/axiosInstanceClient';
+import { DOMAIN } from '@constants/api';
+
+export const postReissue = ({
+  accessToken,
+  refreshToken,
+}: {
+  accessToken: string;
+  refreshToken: string;
+}) => {
+  const requestBody: PostReissueRequestBody = { accessToken, refreshToken };
+  return axiosInstanceClient.post<PostReissueResponse>(
+    DOMAIN.POST_REISSUE,
+    requestBody,
+    {
+      authorization: false,
+    },
+  );
+};
+
+interface PostReissueRequestBody {
+  accessToken: string;
+  refreshToken: string;
+}
+
+interface PostReissueResponse {
+  success: boolean;
+  data: auth;
+}

--- a/src/app/(headerless)/oauth/hooks/useOauthPage.ts
+++ b/src/app/(headerless)/oauth/hooks/useOauthPage.ts
@@ -17,7 +17,7 @@ export default function useOauthPage() {
           await postLogin(code).then((response) => {
             //TODO: 로그인 실패 처리 필요, maxAge 상수화
             const { data } = response;
-            setCookie('auth', data, { maxAge: 2592000 });
+            setCookie('auth', data, { maxAge: 604800 });
             router.push('/home');
             ajajaToast.success('로그인에 성공했습니다.');
           });

--- a/src/app/(headerless)/oauth/hooks/useOauthPage.ts
+++ b/src/app/(headerless)/oauth/hooks/useOauthPage.ts
@@ -15,8 +15,9 @@ export default function useOauthPage() {
       (async () => {
         if (code) {
           await postLogin(code).then((response) => {
+            //TODO: 로그인 실패 처리 필요, maxAge 상수화
             const { data } = response;
-            setCookie('auth', data);
+            setCookie('auth', data, { maxAge: 2592000 });
             router.push('/home');
             ajajaToast.success('로그인에 성공했습니다.');
           });

--- a/src/app/(headerless)/oauth/hooks/useOauthPage.ts
+++ b/src/app/(headerless)/oauth/hooks/useOauthPage.ts
@@ -15,7 +15,7 @@ export default function useOauthPage() {
       (async () => {
         if (code) {
           await postLogin(code).then((response) => {
-            //TODO: 로그인 실패 처리 필요, maxAge 상수화
+            //TODO: 로그인 실패 처리 필요, maxAge 상수화, await 와 then을같이 쓰는게 맞나?
             const { data } = response;
             setCookie('auth', data, { maxAge: 604800 });
             router.push('/home');

--- a/src/app/(headerless)/oauth/hooks/useOauthPage.ts
+++ b/src/app/(headerless)/oauth/hooks/useOauthPage.ts
@@ -25,7 +25,6 @@ export default function useOauthPage() {
     } else if (way === 'logout') {
       deleteCookie('auth');
       router.push('/login');
-      ajajaToast.success('로그아웃에 성공했습니다. ');
     }
   }, [router]);
 }

--- a/src/app/(headerless)/oauth/hooks/useOauthPage.ts
+++ b/src/app/(headerless)/oauth/hooks/useOauthPage.ts
@@ -14,18 +14,23 @@ export default function useOauthPage() {
       const code = new URL(window.location.href).searchParams.get('code');
       (async () => {
         if (code) {
-          await postLogin(code).then((response) => {
-            //TODO: 로그인 실패 처리 필요, maxAge 상수화, await 와 then을같이 쓰는게 맞나?
-            const { data } = response;
-            setCookie('auth', data, { maxAge: 604800 });
-            router.push('/home');
-            ajajaToast.success('로그인에 성공했습니다.');
-          });
+          await postLogin(code)
+            .then((response) => {
+              //TODO: 로그인 실패 처리 필요, maxAge 상수화, await 와 then을같이 쓰는게 맞나?
+              const { data } = response;
+              setCookie('auth', data, { maxAge: 604800 });
+              router.replace('/home');
+              ajajaToast.success('로그인에 성공했습니다.');
+            })
+            .catch(() => {
+              alert('로그인에 실패했습니다. 잠시 후 시도해주세요');
+              router.replace('/login');
+            });
         }
       })();
     } else if (way === 'logout') {
       deleteCookie('auth');
-      router.push('/login');
+      router.replace('/login');
     }
   }, [router]);
 }

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -15,7 +15,7 @@ export const DOMAIN = {
   GET_FEEDBACKS: (userId: number) => `/feedbacks/${userId}`,
   GET_FEEDBACKS_EACH: (planId: number) => `/mock/${planId}/feedbacks`,
 
-  POST_REISSUE: '/mock/reissue',
+  POST_REISSUE: '/reissue',
   POST_LOGIN: `/login`,
 
   GET_PLANS_REMINDS: (planId: number) => `/mock/plans/${planId}/reminds`,

--- a/src/types/apis/ErrorResponseData.ts
+++ b/src/types/apis/ErrorResponseData.ts
@@ -1,0 +1,4 @@
+export interface ErrorResponseData {
+  errorName: string;
+  errorMessage: string;
+}

--- a/src/utils/checkTokenExp.ts
+++ b/src/utils/checkTokenExp.ts
@@ -1,0 +1,8 @@
+import { decodeJWT } from './decodeJWT';
+
+export const checkTokenExp = (token: string) => {
+  const exp = decodeJWT(token).exp;
+  const now = Date.now();
+
+  return exp > now;
+};

--- a/src/utils/decodeJWT.ts
+++ b/src/utils/decodeJWT.ts
@@ -1,0 +1,10 @@
+type AjajaJWTPayload = {
+  ajajajwt: number;
+  exp: number;
+};
+export const decodeJWT = (token: string) => {
+  const base64Payload = token.split('.')[1]; //value 0 -> header, 1 -> payload, 2 -> VERIFY SIGNATURE
+  const payload = Buffer.from(base64Payload, 'base64');
+  const result = JSON.parse(payload.toString()) as AjajaJWTPayload;
+  return result;
+};


### PR DESCRIPTION
## 📌 이슈 번호

close #251 

## 🚀 구현 내용
- accessToken 만료시 토큰 재발행 후 retry를 합니다. 
- accessToken, refreshToken 모두 만료시 다시 로그인 요청
- 로그인 실패시 에러 처리


## 📘 참고 사항

만약 api 요청, 재발행 후 요청에서 문제가 있으면  알려주세요, 아직 모든 에러를 다 못 잡은 것 같습니다. 

## ❓ 궁금한 내용
- 재로그인시 유저에게  실패를 알려줄 때 , toast 보다 alert으로 확실하게 유저가 확인하도록 했습니다. 디자인 달라서 좀 별로인데 다른 방법이 있을까요? 아니면 toast를 alert과 같이 변경할수있을까요? 
- 현재 클라이언트 axiosInstance만 적용됐는데 서버쪽 axiosinstance를 어떻게 할지 잘 모르겠네용