### PR TITLE
[혜수] - 스크롤 적용 위치 변경

### DIFF
--- a/src/app/(header)/explore/_components/Card/index.scss
+++ b/src/app/(header)/explore/_components/Card/index.scss
@@ -2,7 +2,7 @@
 
 $card_width: 19rem;
 $card_height: 12rem;
-$card_margin: 0.5rem;
+$card_margin: 1rem;
 
 @mixin ellipsis($line) {
   text-overflow: ellipsis;
@@ -18,7 +18,7 @@ $card_margin: 0.5rem;
     align-items: center;
     width: 100%;
     box-shadow: var(--origin-shadow);
-    margin: 1rem 0;
+    margin-bottom: 1rem;
     &--image {
       margin: 0 $card_margin 0 $card_margin;
     }

--- a/src/app/(header)/explore/_components/Card/index.scss
+++ b/src/app/(header)/explore/_components/Card/index.scss
@@ -2,7 +2,7 @@
 
 $card_width: 19rem;
 $card_height: 12rem;
-$card_margin: 1rem;
+$card_margin: 0.5rem;
 
 @mixin ellipsis($line) {
   text-overflow: ellipsis;

--- a/src/app/(header)/explore/_components/ExplorePlans.tsx
+++ b/src/app/(header)/explore/_components/ExplorePlans.tsx
@@ -33,30 +33,32 @@ export default function ExplorePlans({ isLogin }: ExplorePlansProps) {
     setCurrent(isNewYear);
   };
   return (
-    <div
-      ref={scrollableRef}
-      className={classNames('explore-plans')}
-      onScroll={handleScroll}>
+    <div className={classNames('explore-plans')}>
       <div className={classNames('explore-plans__wrapper')}>
         <Tab handleSort={handleSort} handleYear={handleYear} />
-        <InfiniteScroll
-          pageStart={0}
-          loadMore={() => fetchNextPage()}
-          hasMore={hasNextPage}
-          loader={
-            <FadeLoader
-              key="loader"
-              color={COLOR.PRIMARY}
-              speedMultiplier={1}
-              className={classNames('explore-plans__loader')}
-            />
-          }
-          useWindow={false}
-          getScrollParent={() => {
-            return scrollableRef.current;
-          }}>
-          <Plans flatLoadedPlans={flatLoadedPlans} isLogin={isLogin} />
-        </InfiniteScroll>
+        <div
+          ref={scrollableRef}
+          onScroll={handleScroll}
+          className={classNames('explore-plans__plans')}>
+          <InfiniteScroll
+            pageStart={0}
+            loadMore={() => fetchNextPage()}
+            hasMore={hasNextPage}
+            loader={
+              <FadeLoader
+                key="loader"
+                color={COLOR.PRIMARY}
+                speedMultiplier={1}
+                className={classNames('explore-plans__loader')}
+              />
+            }
+            useWindow={false}
+            getScrollParent={() => {
+              return scrollableRef.current;
+            }}>
+            <Plans flatLoadedPlans={flatLoadedPlans} isLogin={isLogin} />
+          </InfiniteScroll>
+        </div>
       </div>
       <ToTopFloatingButton />
     </div>

--- a/src/app/(header)/explore/_components/Tab/index.scss
+++ b/src/app/(header)/explore/_components/Tab/index.scss
@@ -7,7 +7,7 @@ $year-gap: 2rem;
     display: flex;
     align-items: flex-end;
     position: relative;
-    margin: 2rem 0 1rem 0;
+    margin: 2rem 0 2rem 0;
     &-year {
       width: $tab-width;
       padding-left: calc($year-gap / 2);

--- a/src/app/(header)/explore/_components/index.scss
+++ b/src/app/(header)/explore/_components/index.scss
@@ -3,7 +3,6 @@
     width: 100%;
     height: 100%;
     &__wrapper {
-      width: 90%;
       height: 100%;
       display: flex;
       flex-direction: column;

--- a/src/app/(header)/explore/_components/index.scss
+++ b/src/app/(header)/explore/_components/index.scss
@@ -2,9 +2,9 @@
   &-plans {
     width: 100%;
     height: 100%;
-    overflow-y: auto;
     &__wrapper {
       width: 90%;
+      height: 100%;
       display: flex;
       flex-direction: column;
       margin: auto;
@@ -12,6 +12,11 @@
     &__loader {
       display: block;
       margin: 0 auto;
+    }
+    &__plans {
+      position: relative;
+      overflow-y: scroll;
+      margin-left: var(--scroll-margin-left);
     }
   }
 }

--- a/src/app/(header)/home/_components/MyPlan.tsx
+++ b/src/app/(header)/home/_components/MyPlan.tsx
@@ -2,6 +2,7 @@
 
 import { Dropdown } from '@/components';
 import { planIcons } from '@/constants/planIcons';
+import { useScroll } from '@/hooks/useScroll';
 import { canMakeNewPlanStore } from '@/stores/canMakeNewPlanStore';
 import { GetMyPlansResponse } from '@/types/apis/plan/GetMyPlans';
 import { checkThisYear } from '@/utils/checkThisYear';
@@ -19,6 +20,7 @@ type MyPlanProps = {
 
 export default function MyPlan({ myPlans }: MyPlanProps) {
   const maxLength = 4;
+  const { handleScroll, scrollableRef } = useScroll();
   const { data: myPlansData } = myPlans;
   const yearList = myPlansData.map((x) => x.year);
   const [year, setYear] = useState(yearList[0]);
@@ -66,7 +68,10 @@ export default function MyPlan({ myPlans }: MyPlanProps) {
           전체 달성률 : {yearData.totalAchieveRate}%
         </div>
       </div>
-      <div className={classNames('home__plans')}>
+      <div
+        className={classNames('home__plans')}
+        ref={scrollableRef}
+        onScroll={handleScroll}>
         {checkThisYear() === year && !yearData.getPlanList.length ? (
           <div className={classNames('home__plans--empty')}>
             <Image src={'/animal/cat.png'} alt="cat" width={100} height={100} />

--- a/src/app/(header)/home/_components/index.scss
+++ b/src/app/(header)/home/_components/index.scss
@@ -28,7 +28,8 @@ $header-height: 11.875rem;
   &__plans {
     width: 100%;
     height: calc(100% - $header-height);
-    overflow-y: auto;
+    overflow-y: scroll;
+    margin-left: var(--scroll-margin-left);
     &--empty {
       display: flex;
       flex-direction: column;

--- a/src/styles/standard.scss
+++ b/src/styles/standard.scss
@@ -1,4 +1,5 @@
 :root {
   --border-radius: 12px;
   --border-width: 1px;
+  --scroll-margin-left: 0.25rem;
 }

--- a/src/styles/webkit.scss
+++ b/src/styles/webkit.scss
@@ -1,28 +1,7 @@
-// body::-webkit-scrollbar {
-//   width: 0.5rem;
-//   height: 0.5rem;
-// }
-
-// body::-webkit-scrollbar-thumb {
-//   height: 50%;
-//   background: var(--origin-white-200);
-
-//   border-radius: var(--border-radius);
-// }
-
-// body::-webkit-scrollbar-track {
-//   background: transparent;
-// }
-
 ::-webkit-scrollbar {
-  width: 0.5rem;
+  width: 0.25rem;
   height: 0.1rem;
 }
-
-// ::-webkit-scrollbar-thumb {
-//   background: var(--origin-gray-100);
-//   border-radius: var(--border-radius);
-// }
 
 ::-webkit-scrollbar-track {
   background: transparent;


### PR DESCRIPTION
## 📌 이슈 번호

close #284 

## 🚀 구현 내용
- explore, home 스크롤 적용 완료
- 스크롤 width 0.25rem으로 변경 완료
- 전역 --scroll-margin-left : 0.25rem 추가
## 📘 참고 사항
- 스크롤 적용은 3d6bbbc 처럼 useScroll 훅을 사용해 스크롤이 생기는 태그에 ref와 onScroll 적용해주면 됩니다!
- 스크롤은 overlay 기능이 deprecated되어 사용할 수 없는 관계로 양옆 마진으로 해결했습니다 😢 
  스크롤이 추가되는 태그에 아래의 css를 추가해주시면 됩니다. `overflow-y:scroll`로 하셔야합니다!(autoX)
```
    overflow-y: scroll;
    margin-left: var(--scroll-margin-left);
```
![image](https://github.com/New-Barams/this-year-ajaja-fe/assets/67812466/13c9be6b-c516-49b9-9b52-15c15c9820ae)

<!--## ❓ 궁금한 내용-->
