### PR TITLE
[민우] - 리마인드 수정 페이지

### DIFF
--- a/src/apis/client/editRemind.ts
+++ b/src/apis/client/editRemind.ts
@@ -1,0 +1,10 @@
+import { DOMAIN } from '@/constants/api';
+import { EditRemindProps } from '@/types/apis/plan/EditRemind';
+import { axiosInstanceClient } from '../axiosInstanceClient';
+
+export const editRemind = async ({ planId, remindData }: EditRemindProps) => {
+  const { data } = await axiosInstanceClient.put(DOMAIN.PUT_REMINDS(planId), {
+    ...remindData,
+  });
+  return data;
+};

--- a/src/app/(header)/create/_components/StepButtonGroup/StepButtonGroup.tsx
+++ b/src/app/(header)/create/_components/StepButtonGroup/StepButtonGroup.tsx
@@ -74,18 +74,22 @@ export default function StepButtonGroup({
       const remindMessage = JSON.parse(remindMessageItem) as RemindItemType[];
 
       const data: PostNewPlanRequestBody = {
-        iconNumber: planIcon,
-        isPublic: planContent.isPublic,
         title: planContent.title,
         description: planContent.description,
-        tags: planContent.tags,
-
         remindTotalPeriod: remindDate.TotalPeriod,
         remindTerm: remindDate.Term,
         remindDate: remindDate.Date,
         remindTime: changeRemindTimeToString(remindDate.Time),
+        isPublic: planContent.isPublic,
+        iconNumber: planIcon,
+        tags: planContent.tags,
+
         messages: remindMessage.map((messageItem) => {
-          return messageItem.message;
+          return {
+            content: messageItem.message,
+            remindMonth: messageItem.date.month,
+            remindDay: messageItem.date.day,
+          };
         }),
       };
 

--- a/src/app/(header)/create/page.tsx
+++ b/src/app/(header)/create/page.tsx
@@ -145,13 +145,14 @@ export default function CreatePage() {
               />
             );
           case 3:
-            return <CreatePlanRemindDate />;
+            return <CreatePlanRemindDate isCreateOrEditPage="create" />;
           case 4:
             return (
               <CreatePlanRemindMessage
                 setIsLastStepDataAllExist={(isExist: boolean) => {
                   setIsLastStepDataAllExist(isExist);
                 }}
+                isCreateOrEditPage="create"
               />
             );
           default:

--- a/src/app/(header)/reminds/[planId]/index.scss
+++ b/src/app/(header)/reminds/[planId]/index.scss
@@ -24,6 +24,7 @@
   &__edit {
     margin-right: 1rem;
     align-self: flex-end;
+    cursor: pointer;
   }
 
   &__content {

--- a/src/app/(header)/reminds/[planId]/page.tsx
+++ b/src/app/(header)/reminds/[planId]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button, DebounceSwitchButton, ReadOnlyRemindItem } from '@/components';
+import { SESSION_STORAGE_KEY } from '@/constants';
 import { REMIND_TIME_TEXT } from '@/constants/remindTimeText';
 import { useGetRemindQuery } from '@/hooks/apis/useGetRemindQuery';
 import { useToggleIsRemindableMutation } from '@/hooks/apis/useToggleIsRemindable';
@@ -9,6 +10,7 @@ import classNames from 'classnames';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import React from 'react';
+import { changeRemindTimeToNumber } from './../../../../utils/changeRemindTimeToNumber';
 import './index.scss';
 
 export default function RemindPage({ params }: { params: { planId: string } }) {
@@ -33,6 +35,33 @@ export default function RemindPage({ params }: { params: { planId: string } }) {
   };
 
   const onClickGoToEditRemind = () => {
+    sessionStorage.removeItem(SESSION_STORAGE_KEY.EDIT_REMIND_OPTION);
+    sessionStorage.setItem(
+      SESSION_STORAGE_KEY.EDIT_REMIND_OPTION,
+      JSON.stringify({
+        TotalPeriod: 12, //TODO: 바꾸기 ! remindData.remindTotalPeriod로
+        Term: 3,
+        Date: 1,
+        Time: changeRemindTimeToNumber(remindData.remindTime),
+      }),
+    );
+
+    sessionStorage.removeItem(SESSION_STORAGE_KEY.EDIT_REMIND_MESSAGE);
+    sessionStorage.setItem(
+      SESSION_STORAGE_KEY.EDIT_REMIND_MESSAGE,
+      JSON.stringify(
+        remindData.messagesResponses.map((message) => {
+          return {
+            date: {
+              month: message.remindMonth,
+              day: message.remindDay,
+            },
+            message: message.remindMessage,
+          };
+        }),
+      ),
+    );
+
     router.push(`/reminds/edit/${planId}`);
   };
 

--- a/src/app/(header)/reminds/[planId]/page.tsx
+++ b/src/app/(header)/reminds/[planId]/page.tsx
@@ -86,16 +86,16 @@ export default function RemindPage({ params }: { params: { planId: string } }) {
           submitToggleAPI={handleToggleIsRemindable}
           toggleName="remind"
         />
-      </div>
 
-      <Button
-        background="primary"
-        color="white-100"
-        border={false}
-        onClick={onClickGoBackToPlan}
-        classNameList={['remind-page__button']}>
-        계획으로 돌아가기
-      </Button>
+        <Button
+          background="primary"
+          color="white-100"
+          border={false}
+          onClick={onClickGoBackToPlan}
+          classNameList={['remind-page__button']}>
+          계획으로 돌아가기
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/app/(header)/reminds/[planId]/page.tsx
+++ b/src/app/(header)/reminds/[planId]/page.tsx
@@ -5,12 +5,12 @@ import { SESSION_STORAGE_KEY } from '@/constants';
 import { REMIND_TIME_TEXT } from '@/constants/remindTimeText';
 import { useGetRemindQuery } from '@/hooks/apis/useGetRemindQuery';
 import { useToggleIsRemindableMutation } from '@/hooks/apis/useToggleIsRemindable';
+import { changeRemindTimeToNumber } from '@/utils/changeRemindTimeToNumber';
 import { checkIsSeason } from '@/utils/checkIsSeason';
 import classNames from 'classnames';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import React from 'react';
-import { changeRemindTimeToNumber } from './../../../../utils/changeRemindTimeToNumber';
 import './index.scss';
 
 export default function RemindPage({ params }: { params: { planId: string } }) {

--- a/src/app/(header)/reminds/edit/[planId]/index.scss
+++ b/src/app/(header)/reminds/edit/[planId]/index.scss
@@ -1,0 +1,34 @@
+.remind-edit-page {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  &__breadcrumb {
+    margin-top: 2rem;
+    align-self: flex-start;
+    display: flex;
+    gap: 0.5rem;
+    a {
+      text-decoration: none;
+      color: var(--origin-text-100);
+    }
+  }
+
+  &__title {
+    font-size: 2rem;
+    margin-top: 2rem;
+    margin-bottom: 0rem;
+  }
+
+  &__button {
+    display: flex;
+    position: absolute;
+    bottom: 6rem;
+    width: calc(100% - 3rem);
+    background-color: transparent;
+    justify-content: end;
+    gap: 24px;
+  }
+}

--- a/src/app/(header)/reminds/edit/[planId]/page.tsx
+++ b/src/app/(header)/reminds/edit/[planId]/page.tsx
@@ -8,9 +8,9 @@ import {
 } from '@/components';
 import { ajajaToast } from '@/components/Toaster/customToast';
 import { SESSION_STORAGE_KEY } from '@/constants';
-// import { useGetRemindQuery } from '@/hooks/apis/useGetRemindQuery';
-import { RemindData, RemindItemType, RemindOptionType } from '@/types/Remind';
-// import { checkIsSeason } from '@/utils/checkIsSeason';
+import { useGetRemindQuery } from '@/hooks/apis/useGetRemindQuery';
+import { RemindItemType, RemindOptionType } from '@/types/Remind';
+import { checkIsSeason } from '@/utils/checkIsSeason';
 import { decideRemindDate } from '@/utils/decideRemindDate';
 import classNames from 'classnames';
 import Link from 'next/link';
@@ -26,26 +26,10 @@ export default function EditRemindPage({
   const { planId } = params;
   const router = useRouter();
 
-  // const { remindData } = useGetRemindQuery(
-  //   parseInt(planId, 10),
-  //   checkIsSeason(),
-  // );
-
-  const remindData: RemindData = {
-    remindTotalPeriod: 12,
-    remindTerm: 1,
-    remindDate: 1,
-    remindTime: 'MORNING',
-    isRemindable: true,
-    messagesResponses: [
-      {
-        remindMessage: '제발 되라',
-        remindMonth: 12,
-        remindDay: 1,
-        isReminded: false,
-      },
-    ],
-  };
+  const { remindData } = useGetRemindQuery(
+    parseInt(planId, 10),
+    checkIsSeason(),
+  );
 
   const [originTerm, setOriginTerm] = useState(1);
   const [originPeriod, setOriginPeriod] = useState(1);

--- a/src/app/(header)/reminds/edit/[planId]/page.tsx
+++ b/src/app/(header)/reminds/edit/[planId]/page.tsx
@@ -1,5 +1,334 @@
-import React from 'react';
+'use client';
 
-export default function EditRemindPage() {
-  return <div>리마인드 수정 페이지</div>;
+import {
+  Button,
+  CreatePlanRemindDate,
+  CreatePlanRemindMessage,
+  ModalFixRemindDate,
+} from '@/components';
+import { ajajaToast } from '@/components/Toaster/customToast';
+import { SESSION_STORAGE_KEY } from '@/constants';
+// import { useGetRemindQuery } from '@/hooks/apis/useGetRemindQuery';
+import { RemindData, RemindItemType, RemindOptionType } from '@/types/Remind';
+// import { checkIsSeason } from '@/utils/checkIsSeason';
+import { decideRemindDate } from '@/utils/decideRemindDate';
+import classNames from 'classnames';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import React, { useEffect, useState } from 'react';
+import './index.scss';
+
+export default function EditRemindPage({
+  params,
+}: {
+  params: { planId: string };
+}) {
+  const { planId } = params;
+  const router = useRouter();
+
+  // const { remindData } = useGetRemindQuery(
+  //   parseInt(planId, 10),
+  //   checkIsSeason(),
+  // );
+
+  const remindData: RemindData = {
+    remindTotalPeriod: 12,
+    remindTerm: 1,
+    remindDate: 1,
+    remindTime: 'MORNING',
+    isRemindable: true,
+    messagesResponses: [
+      {
+        remindMessage: '제발 되라',
+        remindMonth: 12,
+        remindDay: 1,
+        isReminded: false,
+      },
+    ],
+  };
+
+  const [originTerm, setOriginTerm] = useState(1);
+  const [originPeriod, setOriginPeriod] = useState(1);
+
+  useEffect(() => {
+    setOriginTerm(remindData.remindTerm);
+    console.log(`remindTerm: ${remindData.remindTerm}로 변경`);
+  }, [remindData.remindTerm]);
+
+  useEffect(() => {
+    setOriginPeriod(remindData.remindTotalPeriod);
+    console.log(`remindPeriod: ${remindData.remindTotalPeriod}로 변경`);
+  }, [remindData.remindTotalPeriod]);
+
+  const [nowStep, setNowStep] = useState(1);
+  const [isEveryRemindDateExist, setIsEveryRemindDateExist] = useState(false);
+  const [fixedMonthList, setFixedMonthList] = useState<number[]>([]);
+  const [fixedDate, setFixedDate] = useState<number>(1);
+  const [isFixRemindDateModalOpen, setIsFixRemindDateModalOpen] =
+    useState(false);
+
+  useEffect(() => {
+    // 맨 처음 렌더링 시에만 실행 => 이 로직이 위 remindData 받아온 이후에 실행되어야 함
+    sessionStorage.removeItem(SESSION_STORAGE_KEY.EDIT_REMIND_OPTION);
+    sessionStorage.setItem(
+      SESSION_STORAGE_KEY.EDIT_REMIND_OPTION,
+      JSON.stringify({
+        TotalPeriod: remindData.remindTotalPeriod,
+        Term: remindData.remindTerm,
+        Date: remindData.remindDate,
+        Time: remindData.remindTime,
+      }),
+    );
+
+    sessionStorage.removeItem(SESSION_STORAGE_KEY.EDIT_REMIND_MESSAGE);
+    sessionStorage.setItem(
+      SESSION_STORAGE_KEY.EDIT_REMIND_MESSAGE,
+      JSON.stringify(
+        remindData.messagesResponses.map((message) => {
+          return {
+            date: {
+              month: message.remindMonth,
+              day: message.remindDay,
+            },
+            message: message.remindMessage,
+          };
+        }),
+      ),
+    );
+  }, []);
+
+  const goToPreviousStep = () => {
+    if (nowStep > 1) {
+      setNowStep(nowStep - 1);
+    }
+  };
+
+  const goToNextStep = () => {
+    if (nowStep < 2) {
+      setNowStep(nowStep + 1);
+    }
+  };
+
+  const exitEditRemindPage = () => {
+    router.push(`/reminds/${planId}`);
+  };
+
+  const handleClickEditRemind = (isEveryRemindDataExist: boolean) => {
+    if (isEveryRemindDataExist) {
+      // TODO: session Storage에서 data 가지고 api 실행
+
+      ajajaToast.success('리마인드 수정 API 실행');
+      router.push('/home');
+    } else {
+      ajajaToast.error('모든 항목을 입력해주세요!');
+    }
+  };
+
+  // 리마인드 날짜 수정 => 메세지 수정으로 넘어가기 위해 다음 단계 눌렀을 때 실행되는 함수
+  const goToRemindMessageStep = () => {
+    const editRemindOptionsItem = sessionStorage.getItem(
+      SESSION_STORAGE_KEY.EDIT_REMIND_OPTION,
+    );
+
+    const editRemindOptions = editRemindOptionsItem
+      ? (JSON.parse(editRemindOptionsItem) as RemindOptionType)
+      : null;
+
+    if (
+      editRemindOptions?.Term === originTerm &&
+      editRemindOptions?.TotalPeriod === originPeriod
+    ) {
+      // 1. 4번 세션에 대한 session Data를 업데이트 해줘야 함 => 주기, 범위 외에 시간이랑 날짜 바뀌었을 수도 있으므로
+      const remindMessageItem = sessionStorage.getItem(
+        SESSION_STORAGE_KEY.STEP_4,
+      );
+
+      // 기존 4번에 대한 리마인드 메세지 리스트에 접근
+      const remindMessage = remindMessageItem
+        ? (JSON.parse(remindMessageItem) as RemindItemType[])
+        : null;
+
+      if (remindMessage) {
+        // 변경된 날짜에 대한 새로운 리마인드 메세지 리스트 만들기
+        // 일단 날짜 다시 만들고
+        const fixedRemindDateList = decideRemindDate(
+          editRemindOptions.TotalPeriod,
+          editRemindOptions.Term,
+          editRemindOptions.Date,
+        );
+
+        // 새로운 메세지 리스트인데, 월과 날짜가 달라졌을 수도 있으므로 새로 만들고, 메세지는 동일하게
+        const newRemindMessageList = remindMessage.map((item, index) => {
+          return {
+            date: {
+              month: fixedRemindDateList![index].month,
+              day: fixedRemindDateList![index].day,
+            },
+            message: item.message,
+          };
+        });
+
+        sessionStorage.setItem(
+          SESSION_STORAGE_KEY.EDIT_REMIND_MESSAGE,
+          JSON.stringify(newRemindMessageList),
+        );
+      }
+
+      // step + 1
+      goToNextStep();
+    } else {
+      if (editRemindOptions) {
+        const fixedRemindDateList = decideRemindDate(
+          editRemindOptions.TotalPeriod,
+          editRemindOptions.Term,
+          editRemindOptions.Date,
+        );
+
+        setFixedMonthList(
+          fixedRemindDateList!.map((item) => {
+            return item.month;
+          }),
+        );
+        setFixedDate(editRemindOptions.Date);
+        setIsFixRemindDateModalOpen(true);
+      }
+    }
+  };
+
+  const onClickRemindDateModalYes = () => {
+    const remindOptionsItem = sessionStorage.getItem(
+      SESSION_STORAGE_KEY.EDIT_REMIND_OPTION,
+    );
+
+    const remindOptions = remindOptionsItem
+      ? (JSON.parse(remindOptionsItem) as RemindOptionType)
+      : null; // null일수도 있음 ! 사용자가 지웠을 수도 있으니까
+
+    if (remindOptions) {
+      const fixedRemindDateList = decideRemindDate(
+        remindOptions.TotalPeriod,
+        remindOptions.Term,
+        remindOptions.Date,
+      );
+
+      const emptyRemindMessageList: RemindItemType[] = fixedRemindDateList!.map(
+        (item) => {
+          return {
+            date: {
+              month: item.month,
+              day: item.day,
+            },
+            message: '',
+          };
+        },
+      );
+
+      sessionStorage.setItem(
+        SESSION_STORAGE_KEY.EDIT_REMIND_MESSAGE,
+        JSON.stringify(emptyRemindMessageList),
+      );
+
+      // origin에 대한 값을 최신의 period, term으로 교체 => 다시 뒤로가기 할 수도 있으므로
+      console.log(`모달 close => period: ${remindOptions.TotalPeriod}로 변경`);
+      console.log(`모달 close => term: ${remindOptions.Term}로 변경`);
+      setOriginPeriod(remindOptions.TotalPeriod);
+      setOriginTerm(remindOptions.Term);
+
+      setIsFixRemindDateModalOpen(false);
+      goToNextStep();
+    }
+  };
+
+  return (
+    <div className={classNames(['remind-edit-page'])}>
+      <div
+        className={classNames([
+          'remind-edit-page__breadcrumb',
+          'font-size-base',
+          'color-origin-text-100',
+        ])}>
+        {<Link href="/home">홈</Link>}
+        &gt;
+        {<Link href={`/plans/${planId}`}>계획</Link>}
+        &gt;
+        {<Link href={`/reminds/${planId}`}>리마인드</Link>}
+        &gt;
+        <span>리마인드 수정</span>
+      </div>
+
+      <div className={classNames(['remind-edit-page__title'])}>
+        리마인드 날짜 수정
+      </div>
+
+      {nowStep === 1 ? (
+        <CreatePlanRemindDate isCreateOrEditPage="edit" />
+      ) : (
+        <CreatePlanRemindMessage
+          setIsLastStepDataAllExist={setIsEveryRemindDateExist}
+          isCreateOrEditPage="edit"
+        />
+      )}
+
+      <div className={classNames(['remind-edit-page__button'])}>
+        {nowStep === 1 ? (
+          <>
+            <Button
+              background="white-100"
+              border={true}
+              color="primary"
+              onClick={() => {
+                exitEditRemindPage();
+              }}
+              size="sm">
+              나가기
+            </Button>
+            <Button
+              background="primary"
+              border={false}
+              color="white-100"
+              onClick={() => {
+                goToRemindMessageStep();
+              }}>
+              다음 단계
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button
+              background="white-100"
+              border={true}
+              color="primary"
+              onClick={() => {
+                goToPreviousStep();
+              }}
+              size="sm">
+              이전 단계
+            </Button>
+            <Button
+              background="primary"
+              border={false}
+              color="white-100"
+              onClick={() => {
+                handleClickEditRemind(isEveryRemindDateExist);
+              }}>
+              수정 완료
+            </Button>
+          </>
+        )}
+      </div>
+
+      {isFixRemindDateModalOpen && (
+        <ModalFixRemindDate
+          fixedMonthList={fixedMonthList}
+          fixedDate={fixedDate}
+          onClickYes={() => {
+            onClickRemindDateModalYes();
+          }}
+          onClickNo={() => {
+            setIsFixRemindDateModalOpen(false);
+          }}
+        />
+      )}
+    </div>
+  );
 }

--- a/src/app/(header)/reminds/edit/[planId]/page.tsx
+++ b/src/app/(header)/reminds/edit/[planId]/page.tsx
@@ -11,12 +11,12 @@ import { SESSION_STORAGE_KEY } from '@/constants';
 import { useEditRemindMutation } from '@/hooks/apis/useEditRemindMutation';
 import { RemindItemType, RemindOptionType } from '@/types/Remind';
 import { EditRemindData } from '@/types/apis/plan/EditRemind';
+import { changeRemindTimeToString } from '@/utils/changeRemindTimeToString';
 import { decideRemindDate } from '@/utils/decideRemindDate';
 import classNames from 'classnames';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
-import { changeRemindTimeToString } from './../../../../../utils/changeRemindTimeToString';
 import './index.scss';
 
 export default function EditRemindPage({
@@ -72,8 +72,6 @@ export default function EditRemindPage({
 
   const handleClickEditRemind = (isEveryRemindDataExist: boolean) => {
     if (isEveryRemindDataExist) {
-      // TODO: session Storage에서 data 가지고 api 실행
-
       const editRemindOptionsItem = sessionStorage.getItem(
         SESSION_STORAGE_KEY.EDIT_REMIND_OPTION,
       );

--- a/src/components/CreatePlanRemindDate/CreatePlanRemindDate.tsx
+++ b/src/components/CreatePlanRemindDate/CreatePlanRemindDate.tsx
@@ -14,10 +14,19 @@ import classNames from 'classnames';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import './index.scss';
 
-export default function CreatePlanRemindDate() {
+interface CreatePlanRemindDateProps {
+  isCreateOrEditPage: 'create' | 'edit';
+}
+
+export default function CreatePlanRemindDate({
+  isCreateOrEditPage,
+}: CreatePlanRemindDateProps) {
   const [remindOptions, setRemindOptions] = useSessionStorage<RemindOptionType>(
     {
-      key: SESSION_STORAGE_KEY.STEP_3,
+      key:
+        isCreateOrEditPage === 'create'
+          ? SESSION_STORAGE_KEY.STEP_3
+          : SESSION_STORAGE_KEY.EDIT_REMIND_OPTION,
       initialValue: {
         TotalPeriod: 12,
         Term: 3,

--- a/src/components/CreatePlanRemindDate/CreatePlanRemindDate.tsx
+++ b/src/components/CreatePlanRemindDate/CreatePlanRemindDate.tsx
@@ -29,7 +29,7 @@ export default function CreatePlanRemindDate({
           : SESSION_STORAGE_KEY.EDIT_REMIND_OPTION,
       initialValue: {
         TotalPeriod: 12,
-        Term: 3,
+        Term: 1,
         Date: 1,
         Time: 9,
       },

--- a/src/components/CreatePlanRemindMessage/CreatePlanRemindMessage.tsx
+++ b/src/components/CreatePlanRemindMessage/CreatePlanRemindMessage.tsx
@@ -10,14 +10,19 @@ import './index.scss';
 
 interface CreatePlanRemindMessageProps {
   setIsLastStepDataAllExist: (isExist: boolean) => void;
+  isCreateOrEditPage: 'create' | 'edit';
 }
 export default function CreatePlanRemindMessage({
   setIsLastStepDataAllExist,
+  isCreateOrEditPage,
 }: CreatePlanRemindMessageProps) {
   const [remindMessageList, setRemindMessageList] = useSessionStorage<
     RemindItemType[]
   >({
-    key: SESSION_STORAGE_KEY.STEP_4,
+    key:
+      isCreateOrEditPage === 'create'
+        ? SESSION_STORAGE_KEY.STEP_4
+        : SESSION_STORAGE_KEY.EDIT_REMIND_MESSAGE,
     initialValue: [],
     // 이 초기값은 사실 쓰여질 일이 없음 => 3번에서 4번으로 넘어올 때 이미 날짜 확정 모달 클릭 후 각 날짜에 해당하는 기본값을 ""로 설정해주고 넘어왔을 것이므로
   });

--- a/src/components/ModalFixRemindDate/ModalFixRemindDate.tsx
+++ b/src/components/ModalFixRemindDate/ModalFixRemindDate.tsx
@@ -8,6 +8,7 @@ interface ModalFixRemindDateProps {
   fixedDate: number;
   onClickYes: () => void;
   onClickNo: () => void;
+  isPeriodOrTermChanged?: boolean;
 }
 
 export default function ModalFixRemindDate({
@@ -15,6 +16,7 @@ export default function ModalFixRemindDate({
   fixedDate,
   onClickYes,
   onClickNo,
+  isPeriodOrTermChanged = false,
 }: ModalFixRemindDateProps) {
   return (
     <Modal>
@@ -23,6 +25,17 @@ export default function ModalFixRemindDate({
         onClickNo={onClickNo}
         confirmSentense="진행하기">
         <div className={classNames(['fix-remind-modal'])}>
+          {isPeriodOrTermChanged && (
+            <div
+              className={classNames([
+                'fix-remind-modal__isChanged',
+                'font-size-md',
+                'color-origin-primary',
+              ])}>
+              <p>리마인드 기간/주기가 변경되어 </p>
+              <p>작성했던 리마인드 메세지가 삭제됩니다.</p>
+            </div>
+          )}
           <div
             className={classNames([
               'fix-remind-modal__title',

--- a/src/components/ModalFixRemindDate/index.scss
+++ b/src/components/ModalFixRemindDate/index.scss
@@ -4,6 +4,16 @@
   align-items: center;
   justify-content: center;
   
+  &__isChanged{
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    margin-bottom: 1rem;
+    width: 100%;
+  }
+
   &__title{
     display: flex;
     flex-direction: column;

--- a/src/components/Remind/ReadOnlyRemind/ReadOnlyRemind.tsx
+++ b/src/components/Remind/ReadOnlyRemind/ReadOnlyRemind.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ReadOnlyRemindItem } from '@/components';
 import DebounceSwitchButton from '@/components/DebounceSwitchButton/DebounceSwitchButton';
 import {
   DATE_OPTIONS,
@@ -90,31 +89,6 @@ export default function ReadOnlyRemind({ planId }: ReadOnlyRemindProps) {
           에 리마인드를 받고 있어요 !
         </span>
       </div>
-
-      <ul className={classNames('readonly-remind__message__list')}>
-        {remindData.sentRemindResponses &&
-          remindData.sentRemindResponses.map((item, index) => {
-            return (
-              <ReadOnlyRemindItem
-                key={index}
-                data={item}
-                planId={parseInt(planId, 10)}
-                classNameList={['readonly-remind__message__item']}
-              />
-            );
-          })}
-        {remindData.futureRemindResponses &&
-          remindData.futureRemindResponses.map((item, index) => {
-            return (
-              <ReadOnlyRemindItem
-                key={index}
-                data={item}
-                planId={parseInt(planId, 10)}
-                classNameList={['readonly-remind__message__item']}
-              />
-            );
-          })}
-      </ul>
     </div>
   );
 }

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -38,7 +38,7 @@ export const DOMAIN = {
   POST_AJAJA: (planId: number) => `/plans/${planId}/ajaja`,
 
   GET_REMINDS: (planId: number) => `/reminds/${planId}`,
-  GET_REMINDS_MODIFY: (planId: number) => `/reminds/modify/${planId}`,
+  PUT_REMINDS: (planId: number) => `/plans/${planId}/reminds`,
 };
 
 // 실제 API -> swagger 순서입니다.

--- a/src/constants/createPlanSessionKey.ts
+++ b/src/constants/createPlanSessionKey.ts
@@ -4,4 +4,10 @@ export const SESSION_STORAGE_KEY = {
   STEP_3: 'createPlan-remindDate',
   STEP_4: 'createPlan-remindMessage',
   CURRENT_REMIND: 'createPlan-currentRemind',
+
+  EDIT_REMIND_OPTION: 'editRemindOption',
+  EDIT_REMIND_MESSAGE: 'editRemindMessage',
+
+  EDIT_REMIND_PERIOD_ORIGIN: 'editRemindPeriod-origin',
+  EDIT_REMIND_TERM_ORIGIN: 'editRemindTerm-origin',
 };

--- a/src/hooks/apis/useEditRemindMutation.ts
+++ b/src/hooks/apis/useEditRemindMutation.ts
@@ -1,0 +1,24 @@
+import { editRemind } from '@/apis/client/editRemind';
+import { ajajaToast } from '@/components/Toaster/customToast';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useEditRemindMutation = (planId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: editRemind,
+    onSuccess: () => {
+      Promise.all([
+        // TODO: 쿼리 무효화는 더 고민해보기
+        queryClient.invalidateQueries({
+          queryKey: [{ planId: planId }],
+        }),
+      ]);
+      ajajaToast.success('계획 수정 완료');
+    },
+    onError: () => {
+      ajajaToast.error('계획 수정 실패');
+    },
+    throwOnError: true,
+  });
+};

--- a/src/types/Remind.ts
+++ b/src/types/Remind.ts
@@ -26,6 +26,9 @@ export interface ReadOnlyRemindItemData {
 }
 
 export interface RemindData {
+  remindTotalPeriod: number;
+  remindTerm: number;
+  remindDate: number;
   remindTime: 'MORNING' | 'AFTERNOON' | 'EVENING';
   isRemindable: boolean;
   messagesResponses: ReadOnlyRemindItemData[];

--- a/src/types/apis/plan/EditRemind.ts
+++ b/src/types/apis/plan/EditRemind.ts
@@ -1,0 +1,18 @@
+export interface EditRemindData {
+  remindTotalPeriod: number;
+  remindTerm: number;
+  remindDate: number;
+  remindTime: 'MORNING' | 'AFTERNOON' | 'EVENING';
+  messages: EditRemindItem[];
+}
+
+export interface EditRemindProps {
+  planId: number;
+  remindData: EditRemindData;
+}
+
+export interface EditRemindItem {
+  content: string;
+  remindMonth: number;
+  remindDay: number;
+}

--- a/src/types/apis/plan/PostNewPlan.ts
+++ b/src/types/apis/plan/PostNewPlan.ts
@@ -6,7 +6,13 @@ export interface PostNewPlanRequestBody {
   remindDate: number;
   remindTime: 'MORNING' | 'AFTERNOON' | 'EVENING';
   isPublic: boolean;
-  tags: string[];
-  messages: string[];
   iconNumber: number;
+  tags: string[];
+  messages: RemindItem[];
+}
+
+export interface RemindItem {
+  content: string;
+  remindMonth: number;
+  remindDay: number;
 }


### PR DESCRIPTION
## 📌 이슈 번호

close #290 

## 🚀 구현 내용
- [x] 리마인드 수정 페이지 구현
- [x] breadcrumb 적용
- [x] 리마인드 수정 api 연결 
- [x] 세션 스토리지 저장 로직 
- [x] 날짜에서 주기, 범위 변경하지 않을 시 메세지 유지되는 로직 구현 
- [x] 계획 작성 API 연결

<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
