### PR TITLE
[민우] - 작성 페이지 진입 로직 및 디자인 수정

### DIFF
--- a/src/app/(header)/create/page.tsx
+++ b/src/app/(header)/create/page.tsx
@@ -153,45 +153,52 @@ export default function CreatePage() {
         {STEP_NAME[nowStep]}
       </div>
 
-      {(() => {
-        switch (nowStep) {
-          case 1:
-            return (
-              <CreatePlanIcon
-                setIsFirstStepDataAllExist={(isExist: boolean) => {
-                  setIsFirstStepDataAllExist(isExist);
-                }}
-              />
-            );
-          case 2:
-            return (
-              <CreatePlanContent
-                setIsSecondStepDataAllExist={(isExist: boolean) => {
-                  setIsSecondStepDataAllExist(isExist);
-                }}
-              />
-            );
-          case 3:
-            return <CreatePlanRemindDate isCreateOrEditPage="create" />;
-          case 4:
-            return (
-              <CreatePlanRemindMessage
-                setIsLastStepDataAllExist={(isExist: boolean) => {
-                  setIsLastStepDataAllExist(isExist);
-                }}
-                isCreateOrEditPage="create"
-              />
-            );
-          default:
-            return (
-              <CreatePlanIcon
-                setIsFirstStepDataAllExist={(isExist: boolean) => {
-                  setIsFirstStepDataAllExist(isExist);
-                }}
-              />
-            );
-        }
-      })()}
+      {isContinueCreatePlanModalOpen ? (
+        <ModalContinueCreate
+          onClickContinueCreateModalYes={onClickContinueCreateModalYes}
+          onClickContinueCreateModalNo={onClickContinueCreateModalNo}
+        />
+      ) : (
+        (() => {
+          switch (nowStep) {
+            case 1:
+              return (
+                <CreatePlanIcon
+                  setIsFirstStepDataAllExist={(isExist: boolean) => {
+                    setIsFirstStepDataAllExist(isExist);
+                  }}
+                />
+              );
+            case 2:
+              return (
+                <CreatePlanContent
+                  setIsSecondStepDataAllExist={(isExist: boolean) => {
+                    setIsSecondStepDataAllExist(isExist);
+                  }}
+                />
+              );
+            case 3:
+              return <CreatePlanRemindDate isCreateOrEditPage="create" />;
+            case 4:
+              return (
+                <CreatePlanRemindMessage
+                  setIsLastStepDataAllExist={(isExist: boolean) => {
+                    setIsLastStepDataAllExist(isExist);
+                  }}
+                  isCreateOrEditPage="create"
+                />
+              );
+            default:
+              return (
+                <CreatePlanIcon
+                  setIsFirstStepDataAllExist={(isExist: boolean) => {
+                    setIsFirstStepDataAllExist(isExist);
+                  }}
+                />
+              );
+          }
+        })()
+      )}
 
       <StepButtonGroup
         nowStep={nowStep}
@@ -211,13 +218,6 @@ export default function CreatePage() {
           onClickNo={() => {
             setIsFixRemindDateModalOpen(false);
           }}
-        />
-      )}
-
-      {isContinueCreatePlanModalOpen && (
-        <ModalContinueCreate
-          onClickContinueCreateModalYes={onClickContinueCreateModalYes}
-          onClickContinueCreateModalNo={onClickContinueCreateModalNo}
         />
       )}
     </div>

--- a/src/app/(header)/create/page.tsx
+++ b/src/app/(header)/create/page.tsx
@@ -7,6 +7,7 @@ import {
   CreatePlanRemindMessage,
   ModalFixRemindDate,
 } from '@/components';
+import ModalContinueCreate from '@/components/ModalContinueCreate/ModalContinueCreate';
 import { SESSION_STORAGE_KEY } from '@/constants';
 import { STEP_NAME } from '@/constants/createPlanStepTitle';
 import { RemindItemType, RemindOptionType } from '@/types/Remind';
@@ -23,6 +24,13 @@ const StepperComponent = dynamic(
     ssr: false,
   },
 );
+
+const restartCreatePlan = () => {
+  sessionStorage.removeItem(SESSION_STORAGE_KEY.STEP_1);
+  sessionStorage.removeItem(SESSION_STORAGE_KEY.STEP_2);
+  sessionStorage.removeItem(SESSION_STORAGE_KEY.STEP_3);
+  sessionStorage.removeItem(SESSION_STORAGE_KEY.STEP_4);
+};
 
 export default function CreatePage() {
   const [nowStep, setNowStep] = useState(1);
@@ -46,6 +54,25 @@ export default function CreatePage() {
 
   const [fixedMonthList, setFixedMonthList] = useState<number[]>([]);
   const [fixedDate, setFixedDate] = useState<number>(1);
+
+  const isPreviousDataExist = () => {
+    // 1단계의 data가 있으면
+    return sessionStorage.getItem(SESSION_STORAGE_KEY.STEP_1) ? true : false;
+  };
+
+  const [isContinueCreatePlanModalOpen, setIsContinueCreatePlanModalOpen] =
+    useState(isPreviousDataExist());
+
+  const onClickContinueCreateModalYes = () => {
+    // 그냥 모달만 닫아주면 자동으로 이어서 작성
+    setIsContinueCreatePlanModalOpen(false);
+  };
+
+  const onClickContinueCreateModalNo = () => {
+    // 세션 스토리지 값 삭제 후 모달 닫아주기
+    restartCreatePlan();
+    setIsContinueCreatePlanModalOpen(false);
+  };
 
   const [isFixRemindDateModalOpen, setIsFixRemindDateModalOpen] =
     useState(false);
@@ -184,6 +211,13 @@ export default function CreatePage() {
           onClickNo={() => {
             setIsFixRemindDateModalOpen(false);
           }}
+        />
+      )}
+
+      {isContinueCreatePlanModalOpen && (
+        <ModalContinueCreate
+          onClickContinueCreateModalYes={onClickContinueCreateModalYes}
+          onClickContinueCreateModalNo={onClickContinueCreateModalNo}
         />
       )}
     </div>

--- a/src/app/(header)/create/page.tsx
+++ b/src/app/(header)/create/page.tsx
@@ -12,6 +12,7 @@ import { SESSION_STORAGE_KEY } from '@/constants';
 import { STEP_NAME } from '@/constants/createPlanStepTitle';
 import { RemindItemType, RemindOptionType } from '@/types/Remind';
 import { decideRemindDate } from '@/utils/decideRemindDate';
+import { getSessionStorageData } from '@/utils/getSessionStorageData';
 import classNames from 'classnames';
 import dynamic from 'next/dynamic';
 import { useState } from 'react';
@@ -55,21 +56,20 @@ export default function CreatePage() {
   const [fixedMonthList, setFixedMonthList] = useState<number[]>([]);
   const [fixedDate, setFixedDate] = useState<number>(1);
 
-  const isPreviousDataExist = () => {
-    // 1단계의 data가 있으면
+  const isPreviousCreatePlanExist = () => {
     return sessionStorage.getItem(SESSION_STORAGE_KEY.STEP_1) ? true : false;
   };
 
   const [isContinueCreatePlanModalOpen, setIsContinueCreatePlanModalOpen] =
-    useState(isPreviousDataExist());
+    useState(isPreviousCreatePlanExist());
 
   const onClickContinueCreateModalYes = () => {
-    // 그냥 모달만 닫아주면 자동으로 이어서 작성
+    // 이어서 작성하기 - 모달만 닫기
     setIsContinueCreatePlanModalOpen(false);
   };
 
   const onClickContinueCreateModalNo = () => {
-    // 세션 스토리지 값 삭제 후 모달 닫아주기
+    // 새로 작성하기 - 모든 step 세션 스토리지 값 삭제 후 모달 닫기
     restartCreatePlan();
     setIsContinueCreatePlanModalOpen(false);
   };
@@ -77,17 +77,12 @@ export default function CreatePage() {
   const [isFixRemindDateModalOpen, setIsFixRemindDateModalOpen] =
     useState(false);
 
-  // nowStep=3에서, 다음 단계 버튼 누르면 실행되는 함수
+  // 3 => 4단계 다음단계 버튼 클릭 시 실행되는 함수
+  // 날짜 확정 모달에 렌더링 될 data들을 3단계에서 정한 주기, 범위, 날짜로 업데이트 시켜주고 모달 열기
   const goToLastStep = () => {
-    // 모달에 연결되어있는 data들을 3번 단계에서 정한 주기, 범위, 날짜로 업데이트 시켜주고
-    // 그 이후에 모달 open 상태를 true로 만들어주기
-    const remindOptionsItem = sessionStorage.getItem(
-      SESSION_STORAGE_KEY.STEP_3,
-    );
-
-    const remindOptions = remindOptionsItem
-      ? (JSON.parse(remindOptionsItem) as RemindOptionType)
-      : null; // null일수도 있음 ! 사용자가 지웠을 수도 있으니까
+    const remindOptions = getSessionStorageData(
+      'STEP_3',
+    ) as RemindOptionType | null;
 
     if (remindOptions) {
       const fixedRemindDateList = decideRemindDate(
@@ -106,15 +101,16 @@ export default function CreatePage() {
     }
   };
 
+  // 날짜 확정 모달에서 yes를 눌렀을 시 실행되는 함수
+  // 3단계 data를 바탕으로 정해진 날짜와 비어있는 메세지 "" 를 4단계 session data로 저장, 모달 닫기
   const onClickRemindDateModalYes = () => {
-    // 모달에서 yes를 눌렀을 시, 3번 data를 바탕으로 정해진 날짜 - "" 를 4번 key에 대해 저장, 모달 닫기
     const remindOptionsItem = sessionStorage.getItem(
       SESSION_STORAGE_KEY.STEP_3,
     );
 
     const remindOptions = remindOptionsItem
       ? (JSON.parse(remindOptionsItem) as RemindOptionType)
-      : null; // null일수도 있음 ! 사용자가 지웠을 수도 있으니까
+      : null;
 
     if (remindOptions) {
       const fixedRemindDateList = decideRemindDate(
@@ -214,7 +210,9 @@ export default function CreatePage() {
         <ModalFixRemindDate
           fixedMonthList={fixedMonthList}
           fixedDate={fixedDate}
-          onClickYes={onClickRemindDateModalYes}
+          onClickYes={() => {
+            onClickRemindDateModalYes();
+          }}
           onClickNo={() => {
             setIsFixRemindDateModalOpen(false);
           }}

--- a/src/components/CreatePlanContent/CreatePlanContent.tsx
+++ b/src/components/CreatePlanContent/CreatePlanContent.tsx
@@ -104,17 +104,19 @@ export default function CreatePlanContent({
         classNameList={['create-plan-content__plan-input__second']}
       />
 
-      <div className={classNames('create-plan-content__tags')}>
+      <div className={classNames('create-plan-content__tag')}>
         <InputTag onSubmit={handleAddTag} />
-        {planContent.tags.map((tag, index) => (
-          <Tag
-            key={index}
-            onClick={() => {
-              handleRemoveTag(tag);
-            }}>
-            {tag}
-          </Tag>
-        ))}
+        <div className="create-plan-content__tag--tags">
+          {planContent.tags.map((tag, index) => (
+            <Tag
+              key={index}
+              onClick={() => {
+                handleRemoveTag(tag);
+              }}>
+              {tag}
+            </Tag>
+          ))}
+        </div>
       </div>
 
       <div className={classNames('create-plan-content__public')}>

--- a/src/components/CreatePlanContent/CreatePlanContent.tsx
+++ b/src/components/CreatePlanContent/CreatePlanContent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { SESSION_STORAGE_KEY } from '@/constants';
+import { useScroll } from '@/hooks/useScroll';
 import { PlanContentType } from '@/types/Plan';
 import classNames from 'classnames';
 import { useEffect, useRef } from 'react';
@@ -34,6 +35,8 @@ export default function CreatePlanContent({
       setIsSecondStepDataAllExist(false);
     }
   }, [planContent, setIsSecondStepDataAllExist]);
+
+  const { handleScroll, scrollableRef } = useScroll();
 
   const nextTextAreaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -75,7 +78,10 @@ export default function CreatePlanContent({
   };
 
   return (
-    <div className={classNames('create-plan-content')}>
+    <div
+      className={classNames('create-plan-content')}
+      ref={scrollableRef}
+      onScroll={handleScroll}>
       <PlanInput
         editable={true}
         kind="title"

--- a/src/components/CreatePlanContent/index.scss
+++ b/src/components/CreatePlanContent/index.scss
@@ -3,7 +3,8 @@
   flex-direction: column;
   width: 100%;
   max-height: calc(100% - 12.25rem);
-  overflow-y: auto;
+  overflow-y: scroll;
+  margin-left: var(--scroll-margin-left);
 
   &__plan-input {
     &__first {

--- a/src/components/CreatePlanContent/index.scss
+++ b/src/components/CreatePlanContent/index.scss
@@ -16,8 +16,17 @@
     }
   }
 
-  &__tags {
+  &__tag {
     margin-top: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    &--tags {
+      display: flex;
+      gap: 0rem 0.5rem;
+      flex-wrap: wrap;
+    }
   }
 
   &__public {
@@ -29,6 +38,7 @@
     &__button {
       display: flex;
       align-items: center;
+      gap: 0.5rem;
       width: 100%;
     }
   }
@@ -42,6 +52,8 @@
     &__button {
       display: flex;
       align-items: center;
+      gap: 0.5rem;
+      width: 100%;
     }
   }
 }

--- a/src/components/CreatePlanIcon/CreatePlanIcon.tsx
+++ b/src/components/CreatePlanIcon/CreatePlanIcon.tsx
@@ -2,6 +2,7 @@
 
 import { SESSION_STORAGE_KEY } from '@/constants';
 import { planIcons } from '@/constants/planIcons';
+import { useScroll } from '@/hooks/useScroll';
 import classNames from 'classnames';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
@@ -24,13 +25,20 @@ export default function CreatePlanIcon({
   useEffect(() => {
     if (iconNumber) {
       setIsFirstStepDataAllExist(true);
+    } else {
+      setIsFirstStepDataAllExist(false);
     }
   }, [iconNumber, setIsFirstStepDataAllExist]);
+
+  const { handleScroll, scrollableRef } = useScroll();
 
   const [isSelectIconModalOpen, setIsSelectIconModalOpen] = useState(false);
 
   return (
-    <div className={classNames('create-plan-icon')}>
+    <div
+      className={classNames('create-plan-icon')}
+      ref={scrollableRef}
+      onScroll={handleScroll}>
       <div
         className={classNames('create-plan-icon__question', 'font-size-base')}>
         계획을 대표할 아이콘을 정해볼까요?

--- a/src/components/CreatePlanIcon/index.scss
+++ b/src/components/CreatePlanIcon/index.scss
@@ -3,7 +3,8 @@
   flex-direction: column;
   width: 100%;
   max-height: calc(100% - 12.25rem);
-  overflow-y: auto;
+  overflow-y: scroll;
+  margin-left: var(--scroll-margin-left);
   align-items: center;
 
   &__question {

--- a/src/components/CreatePlanRemindDate/CreatePlanRemindDate.tsx
+++ b/src/components/CreatePlanRemindDate/CreatePlanRemindDate.tsx
@@ -8,6 +8,7 @@ import {
   TIME_OPTIONS,
   TOTAL_PERIOD_OPTIONS,
 } from '@/constants/remindOptions';
+import { useScroll } from '@/hooks/useScroll';
 import { useSessionStorage } from '@/hooks/useSessionStorage';
 import { RemindOptionType } from '@/types/Remind';
 import classNames from 'classnames';
@@ -37,6 +38,8 @@ export default function CreatePlanRemindDate({
     },
   );
 
+  const { handleScroll, scrollableRef } = useScroll();
+
   const handleChangeRemindOption = useCallback(
     (optionKey: string, newOptionValue: number) => {
       setRemindOptions({
@@ -60,7 +63,10 @@ export default function CreatePlanRemindDate({
   }, [remindOptions.TotalPeriod, remindOptions.Term, handleChangeRemindOption]);
 
   return (
-    <div className={classNames(['create-remind-date'])}>
+    <div
+      className={classNames(['create-remind-date'])}
+      ref={scrollableRef}
+      onScroll={handleScroll}>
       <p className={classNames(['create-remind-date__title'])}>
         1년 중, 리마인드를 받고 싶은 날짜를 정해보세요!
       </p>

--- a/src/components/CreatePlanRemindDate/index.scss
+++ b/src/components/CreatePlanRemindDate/index.scss
@@ -3,7 +3,8 @@
   flex-direction: column;
   width: 100%;
   max-height: calc(100% - 12.25rem);
-  overflow-y: auto;
+  overflow-y: scroll;
+  margin-left: var(--scroll-margin-left);
 
 
   &__title{

--- a/src/components/CreatePlanRemindMessage/CreatePlanRemindMessage.tsx
+++ b/src/components/CreatePlanRemindMessage/CreatePlanRemindMessage.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { SESSION_STORAGE_KEY } from '@/constants';
+import { useScroll } from '@/hooks/useScroll';
 import { useSessionStorage } from '@/hooks/useSessionStorage';
 import { RemindItemType } from '@/types/Remind';
 import classNames from 'classnames';
@@ -40,6 +41,8 @@ export default function CreatePlanRemindMessage({
     }
   }, [remindMessageList, setIsLastStepDataAllExist]);
 
+  const { handleScroll, scrollableRef } = useScroll();
+
   const handleChangeRemindMessage = (
     month: number,
     day: number,
@@ -66,7 +69,10 @@ export default function CreatePlanRemindMessage({
   }, [remindMessageList, setRemindMessageList]);
 
   return (
-    <div className={classNames(['create-remind-message'])}>
+    <div
+      className={classNames(['create-remind-message'])}
+      ref={scrollableRef}
+      onScroll={handleScroll}>
       <div className={classNames(['create-remind-message__title'])}>
         선택받은 날짜에 받을 리마인드 메세지를 작성해주세요 !
       </div>

--- a/src/components/CreatePlanRemindMessage/CreatePlanRemindMessage.tsx
+++ b/src/components/CreatePlanRemindMessage/CreatePlanRemindMessage.tsx
@@ -25,7 +25,6 @@ export default function CreatePlanRemindMessage({
         ? SESSION_STORAGE_KEY.STEP_4
         : SESSION_STORAGE_KEY.EDIT_REMIND_MESSAGE,
     initialValue: [],
-    // 이 초기값은 사실 쓰여질 일이 없음 => 3번에서 4번으로 넘어올 때 이미 날짜 확정 모달 클릭 후 각 날짜에 해당하는 기본값을 ""로 설정해주고 넘어왔을 것이므로
   });
 
   useEffect(() => {
@@ -37,7 +36,6 @@ export default function CreatePlanRemindMessage({
       } else {
         setIsLastStepDataAllExist(false);
       }
-      // TODO: 1,2,3단계에 대한 is~StepDataAllExist가 true일 때도 검사해줘야할까
     }
   }, [remindMessageList, setIsLastStepDataAllExist]);
 
@@ -58,7 +56,6 @@ export default function CreatePlanRemindMessage({
     );
   };
 
-  // 이게 첫 번째 리마인드 메세지가 변할 때에만 이뤄줘야 함
   const makeAllRemindMessageSame = useCallback(() => {
     if (remindMessageList.length > 1) {
       const firstMessage = remindMessageList[0].message;

--- a/src/components/CreatePlanRemindMessage/index.scss
+++ b/src/components/CreatePlanRemindMessage/index.scss
@@ -3,7 +3,8 @@
   flex-direction: column;
   width: 100%;
   max-height: calc(100% - 12.25rem);
-  overflow-y: auto;
+  overflow-y: scroll;
+  margin-left: var(--scroll-margin-left);
 
   &__title{
     margin-top: 1rem;

--- a/src/components/DebounceSwitchButton/index.scss
+++ b/src/components/DebounceSwitchButton/index.scss
@@ -4,8 +4,7 @@
 
   &__text {
     margin-left: 0.5rem;
-    color: var(--origin-gray-200);
-    font-size: 1rem;
+    color: var(--origin-text-100);
     white-space: pre-wrap;
     text-align: center;
   }

--- a/src/components/ModalContinueCreate/ModalContinueCreate.tsx
+++ b/src/components/ModalContinueCreate/ModalContinueCreate.tsx
@@ -16,7 +16,7 @@ export default function ModalContinueCreate({
   onClickContinueCreateModalNo,
 }: ModalContinueCreateProps) {
   const backgroundRef = useRef<HTMLDivElement | null>(null);
-  useModalClose(backgroundRef, onClickContinueCreateModalNo);
+  useModalClose(backgroundRef, onClickContinueCreateModalYes);
 
   return (
     <Modal>

--- a/src/components/ModalContinueCreate/ModalContinueCreate.tsx
+++ b/src/components/ModalContinueCreate/ModalContinueCreate.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useModalClose } from '@/hooks/useModalClose';
+import classNames from 'classnames';
+import React, { useRef } from 'react';
+import { Button, Modal } from '..';
+import './index.scss';
+
+interface ModalContinueCreateProps {
+  onClickContinueCreateModalYes: () => void;
+  onClickContinueCreateModalNo: () => void;
+}
+
+export default function ModalContinueCreate({
+  onClickContinueCreateModalYes,
+  onClickContinueCreateModalNo,
+}: ModalContinueCreateProps) {
+  const backgroundRef = useRef<HTMLDivElement | null>(null);
+  useModalClose(backgroundRef, onClickContinueCreateModalNo);
+
+  return (
+    <Modal>
+      <div
+        className={classNames([
+          'continue-create-modal__wrapper',
+          'background-origin-white-100',
+        ])}
+        ref={backgroundRef}>
+        <div className={classNames(['continue-create-modal__content'])}>
+          <div className={classNames(['continue-create-modal__content__text'])}>
+            <p>작성 중인 계획이 있습니다.</p>
+            <p>이어서 계획을 작성하시겠습니까?</p>
+          </div>
+
+          <div
+            className={classNames([
+              'continue-create-modal__content__button-group',
+            ])}>
+            <Button
+              background="white-100"
+              border={true}
+              color="primary"
+              onClick={() => {
+                onClickContinueCreateModalYes();
+              }}>
+              이어서 작성
+            </Button>
+            <Button
+              background="primary"
+              border={false}
+              color="white-100"
+              onClick={() => {
+                onClickContinueCreateModalNo();
+              }}>
+              새로 작성
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/ModalContinueCreate/index.scss
+++ b/src/components/ModalContinueCreate/index.scss
@@ -1,0 +1,33 @@
+.continue-create-modal{
+  &__wrapper {
+    border-radius: var(--border-radius);
+    border-top: 1px solid var(--origin-secondary);
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__content{
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: calc(100% - 3rem);
+
+    &__text{
+      margin-top: 2.5rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+  
+    &__button-group{
+      margin-top: 2rem;  
+      width: 100%;
+      display: flex;
+      justify-content: end;
+      margin-bottom: 2rem;
+      gap: 24px;
+    }
+  }
+}

--- a/src/constants/createPlanSessionKey.ts
+++ b/src/constants/createPlanSessionKey.ts
@@ -3,11 +3,7 @@ export const SESSION_STORAGE_KEY = {
   STEP_2: 'createPlan-content',
   STEP_3: 'createPlan-remindDate',
   STEP_4: 'createPlan-remindMessage',
-  CURRENT_REMIND: 'createPlan-currentRemind',
 
   EDIT_REMIND_OPTION: 'editRemindOption',
   EDIT_REMIND_MESSAGE: 'editRemindMessage',
-
-  EDIT_REMIND_PERIOD_ORIGIN: 'editRemindPeriod-origin',
-  EDIT_REMIND_TERM_ORIGIN: 'editRemindTerm-origin',
 };

--- a/src/utils/getSessionStorageData.ts
+++ b/src/utils/getSessionStorageData.ts
@@ -1,0 +1,46 @@
+import { SESSION_STORAGE_KEY } from '@/constants';
+import { PlanContentType } from '@/types/Plan';
+import { RemindItemType, RemindOptionType } from '@/types/Remind';
+
+type SessionStorageKey = keyof typeof SESSION_STORAGE_KEY;
+
+export const getSessionStorageData = (key: SessionStorageKey) => {
+  switch (key) {
+    case 'STEP_1': {
+      const item = sessionStorage.getItem(SESSION_STORAGE_KEY.STEP_1);
+      return item ? (JSON.parse(item) as number) : null;
+    }
+
+    case 'STEP_2': {
+      const item = sessionStorage.getItem(SESSION_STORAGE_KEY.STEP_1);
+      return item ? (JSON.parse(item) as PlanContentType) : null;
+    }
+
+    case 'STEP_3': {
+      const item = sessionStorage.getItem(SESSION_STORAGE_KEY.STEP_3);
+      return item ? (JSON.parse(item) as RemindOptionType) : null;
+    }
+
+    case 'STEP_4': {
+      const item = sessionStorage.getItem(SESSION_STORAGE_KEY.STEP_4);
+      return item ? (JSON.parse(item) as RemindItemType[]) : null;
+    }
+
+    case 'EDIT_REMIND_OPTION': {
+      const item = sessionStorage.getItem(
+        SESSION_STORAGE_KEY.EDIT_REMIND_OPTION,
+      );
+      return item ? (JSON.parse(item) as RemindOptionType) : null;
+    }
+
+    case 'EDIT_REMIND_MESSAGE': {
+      const item = sessionStorage.getItem(
+        SESSION_STORAGE_KEY.EDIT_REMIND_MESSAGE,
+      );
+      return item ? (JSON.parse(item) as RemindItemType[]) : null;
+    }
+
+    default:
+      return null;
+  }
+};


### PR DESCRIPTION
## 📌 이슈 번호
close #296 

## 🚀 구현 내용
<img width="326" alt="image" src="https://github.com/New-Barams/this-year-ajaja-fe/assets/31370590/ae06ac96-2334-402c-83e2-401f7d10e81a">
- [x]  작성 페이지 진입 로직 ⇒ 작성 중인 계획 있을 때 `이어서 작성`  VS  `새로 작성` 선택 모달 구현
- [x]  작성 페이지 useScroll 훅 이용 스크롤 적용
- [x]  작성 페이지 태그끼리 위 아래, 양옆 패딩 조정
- [x]  계획 작성 페이지 Tag 및 SwitchButton padding 및 위치 수정
- [x]  DebounceSwitchButton 폰트 크기 및 색상 수정]

## 아직 구현하지 못한 부분 
- [ ]  3 ⇒ 4단계 진입 시 리마인드 `주기`, `범위` 바뀌었을 때만 메세지 초기화 로직

<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
