### PR TITLE
[민우] - 리마인드 정보 조회, 수정 API 연결

### DIFF
--- a/src/app/(header)/create/_components/StepButtonGroup/StepButtonGroup.tsx
+++ b/src/app/(header)/create/_components/StepButtonGroup/StepButtonGroup.tsx
@@ -94,7 +94,6 @@ export default function StepButtonGroup({
       };
 
       createNewPlanAPI(data);
-      ajajaToast.success('계획 작성 API 실행');
       router.push('/home');
     } else {
       ajajaToast.error('모든 항목을 입력해주세요!');

--- a/src/app/(header)/create/index.scss
+++ b/src/app/(header)/create/index.scss
@@ -1,4 +1,4 @@
-.new-create-page{
+.create-page{
   width: 100%;
   height: 100%;
   display: flex;

--- a/src/app/(header)/create/page.tsx
+++ b/src/app/(header)/create/page.tsx
@@ -142,10 +142,10 @@ export default function CreatePage() {
   };
 
   return (
-    <div className={classNames('new-create-page')}>
+    <div className={classNames('create-page')}>
       <StepperComponent nowStep={nowStep - 1} />
 
-      <div className={classNames('new-create-page__title', 'font-size-xl')}>
+      <div className={classNames('create-page__title', 'font-size-xl')}>
         {STEP_NAME[nowStep]}
       </div>
 

--- a/src/app/(header)/reminds/[planId]/index.scss
+++ b/src/app/(header)/reminds/[planId]/index.scss
@@ -33,7 +33,8 @@
     align-items: flex-start;
     width: 100%;
     max-height: calc(100% - 14rem);
-    overflow-y: auto;
+    overflow-y: scroll;
+    margin-left: var(--scroll-margin-left);
     padding-bottom: 1rem;
 
     &__message-list {

--- a/src/app/(header)/reminds/[planId]/page.tsx
+++ b/src/app/(header)/reminds/[planId]/page.tsx
@@ -5,6 +5,7 @@ import { SESSION_STORAGE_KEY } from '@/constants';
 import { REMIND_TIME_TEXT } from '@/constants/remindTimeText';
 import { useGetRemindQuery } from '@/hooks/apis/useGetRemindQuery';
 import { useToggleIsRemindableMutation } from '@/hooks/apis/useToggleIsRemindable';
+import { useScroll } from '@/hooks/useScroll';
 import { changeRemindTimeToNumber } from '@/utils/changeRemindTimeToNumber';
 import { checkIsSeason } from '@/utils/checkIsSeason';
 import classNames from 'classnames';
@@ -16,6 +17,7 @@ import './index.scss';
 export default function RemindPage({ params }: { params: { planId: string } }) {
   const { planId } = params;
   const router = useRouter();
+  const { handleScroll, scrollableRef } = useScroll();
 
   const { remindData } = useGetRemindQuery(
     parseInt(planId, 10),
@@ -89,7 +91,10 @@ export default function RemindPage({ params }: { params: { planId: string } }) {
         수정
       </p>
 
-      <div className={classNames(['remind-page__content'])}>
+      <div
+        className={classNames(['remind-page__content'])}
+        ref={scrollableRef}
+        onScroll={handleScroll}>
         <ul className={classNames(['remind-page__content__message-list'])}>
           {remindData.messagesResponses.map((item, index) => {
             return (

--- a/src/app/(header)/reminds/[planId]/page.tsx
+++ b/src/app/(header)/reminds/[planId]/page.tsx
@@ -39,9 +39,9 @@ export default function RemindPage({ params }: { params: { planId: string } }) {
     sessionStorage.setItem(
       SESSION_STORAGE_KEY.EDIT_REMIND_OPTION,
       JSON.stringify({
-        TotalPeriod: 12, //TODO: 바꾸기 ! remindData.remindTotalPeriod로
-        Term: 3,
-        Date: 1,
+        TotalPeriod: remindData.totalPeriod,
+        Term: remindData.remindTerm,
+        Date: remindData.remindDate,
         Time: changeRemindTimeToNumber(remindData.remindTime),
       }),
     );

--- a/src/app/(header)/reminds/edit/[planId]/page.tsx
+++ b/src/app/(header)/reminds/edit/[planId]/page.tsx
@@ -103,8 +103,6 @@ export default function EditRemindPage({
           planId: parseInt(planId, 10),
           remindData: editRemindData,
         });
-
-        ajajaToast.success('리마인드 수정 API 실행'); // TODO: 다 되면 지우기
       }
       router.push('/home');
     } else {

--- a/src/app/(header)/reminds/edit/[planId]/page.tsx
+++ b/src/app/(header)/reminds/edit/[planId]/page.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/components';
 import { ajajaToast } from '@/components/Toaster/customToast';
 import { SESSION_STORAGE_KEY } from '@/constants';
+import { EDIT_REMIND_STEP_TITLE } from '@/constants/editRemindStepTitle';
 import { useEditRemindMutation } from '@/hooks/apis/useEditRemindMutation';
 import { RemindItemType, RemindOptionType } from '@/types/Remind';
 import { EditRemindData } from '@/types/apis/plan/EditRemind';
@@ -230,7 +231,7 @@ export default function EditRemindPage({
       </div>
 
       <div className={classNames(['remind-edit-page__title'])}>
-        리마인드 날짜 수정
+        {EDIT_REMIND_STEP_TITLE[nowStep]}
       </div>
 
       {nowStep === 1 ? (

--- a/src/components/CreatePlanIcon/CreatePlanIcon.tsx
+++ b/src/components/CreatePlanIcon/CreatePlanIcon.tsx
@@ -80,7 +80,7 @@ export default function CreatePlanIcon({
             'create-plan-icon__example__text',
             'font-size-xs',
           )}>
-          선택된 아이콘은 계획이 생성되었을 때 다음과 같이 보여요 !
+          선택된 아이콘은 계획이 생성되었을 때 다음과 같이 보여요!
         </div>
         <CreatePlanIconExample />
       </div>

--- a/src/components/CreatePlanIcon/index.scss
+++ b/src/components/CreatePlanIcon/index.scss
@@ -13,6 +13,7 @@
 
   &__icon-image {
     margin-top: 1.25rem;
+    cursor: pointer;
   }
 
   &__icon-text {

--- a/src/components/CreatePlanIconExample/CreatePlanIconExample.tsx
+++ b/src/components/CreatePlanIconExample/CreatePlanIconExample.tsx
@@ -14,7 +14,7 @@ export default function CreatePlanIconExample() {
         'border-round',
       )}>
       <Image
-        src={`/animal/${planIcons[2]}.png`}
+        src={`/animal/${planIcons[7]}.png`}
         width={90}
         height={90}
         alt="example plan icon"

--- a/src/components/CreatePlanRemindMessage/CreatePlanRemindMessage.tsx
+++ b/src/components/CreatePlanRemindMessage/CreatePlanRemindMessage.tsx
@@ -71,7 +71,7 @@ export default function CreatePlanRemindMessage({
       ref={scrollableRef}
       onScroll={handleScroll}>
       <div className={classNames(['create-remind-message__title'])}>
-        선택받은 날짜에 받을 리마인드 메세지를 작성해주세요 !
+        선택받은 날짜에 받을 리마인드 메세지를 작성해주세요!
       </div>
 
       <ul className={classNames(['create-remind-message__list'])}>

--- a/src/components/CreatePlanRemindMessage/index.scss
+++ b/src/components/CreatePlanRemindMessage/index.scss
@@ -17,5 +17,6 @@
     display: flex;
     flex-direction: column;
     gap: 1rem;
+    padding-bottom: 1rem;
   }
 }

--- a/src/components/Remind/ReadOnlyRemind/ReadOnlyRemind.tsx
+++ b/src/components/Remind/ReadOnlyRemind/ReadOnlyRemind.tsx
@@ -64,7 +64,7 @@ export default function ReadOnlyRemind({ planId }: ReadOnlyRemindProps) {
         <span className={classNames('readonly-remind__options__option')}>
           {makeRemindOptionToString(
             TOTAL_PERIOD_OPTIONS,
-            remindData.remindTotalPeriod,
+            remindData.totalPeriod,
           )}
         </span>
         <span className={classNames('readonly-remind__options__text')}>

--- a/src/constants/editRemindStepTitle.ts
+++ b/src/constants/editRemindStepTitle.ts
@@ -1,0 +1,8 @@
+type RemindStepTitleMap = {
+  [key: number]: string;
+};
+
+export const EDIT_REMIND_STEP_TITLE: RemindStepTitleMap = {
+  1: '리마인드 날짜 수정',
+  2: '리마인드 메세지 수정',
+};

--- a/src/types/Remind.ts
+++ b/src/types/Remind.ts
@@ -26,7 +26,7 @@ export interface ReadOnlyRemindItemData {
 }
 
 export interface RemindData {
-  remindTotalPeriod: number;
+  totalPeriod: number;
   remindTerm: number;
   remindDate: number;
   remindTime: 'MORNING' | 'AFTERNOON' | 'EVENING';


### PR DESCRIPTION
## 📌 이슈 번호

close #306 

## 🚀 구현 내용
- [x] 리마인드 상세 ⇒ 수정 클릭 시 세션에 저장하는 값 remindData로 교체
- [x] 리마인드 페이지, 리마인드 수정 페이지 스크롤 적용 
- [x]  cursor 포인터 적용
- [x] 불필요한 toast 제거

<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
