### PR TITLE
[혜수] - 둘러보기 페이지 UI 수정 & 홈 설문조사 링크 추가 

### DIFF
--- a/src/app/(header)/explore/_components/Card/Card.tsx
+++ b/src/app/(header)/explore/_components/Card/Card.tsx
@@ -41,23 +41,14 @@ export default function Card({ plan }: CardProps) {
           disabled
         />
         <div className={classNames('card__contents--tags')}>
-          {plan.tags.length ? (
-            <>
-              {plan.tags.map((tag, index) => {
-                return (
-                  <Tag key={index} style={{ padding: ' 0 0.25rem' }}>
-                    {tag}
-                  </Tag>
-                );
-              })}
-            </>
-          ) : (
-            <p className={classNames('font-size-sm', 'color-origin-secondary')}>
-              태그가 없습니다.
-            </p>
-          )}
+          {plan.tags.map((tag, index) => {
+            return (
+              <Tag key={index} style={{ padding: ' 0 0.25rem' }}>
+                {tag}
+              </Tag>
+            );
+          })}
         </div>
-        {/* </div> */}
       </div>
     </div>
   );

--- a/src/app/(header)/explore/_components/Card/Card.tsx
+++ b/src/app/(header)/explore/_components/Card/Card.tsx
@@ -18,8 +18,8 @@ export default function Card({ plan }: CardProps) {
       )}>
       <Image
         src={`/animal/${planIcons[plan.iconNumber]}.png`}
-        width={60}
-        height={60}
+        width={64}
+        height={64}
         alt="animal icon"
         className={classNames('card__wrapper--image')}
       />

--- a/src/app/(header)/explore/_components/Card/index.scss
+++ b/src/app/(header)/explore/_components/Card/index.scss
@@ -3,6 +3,7 @@
 $card_width: 19rem;
 $card_height: 12rem;
 $card_margin: 0.5rem;
+$card_image_margin: 1rem;
 
 @mixin ellipsis($line) {
   text-overflow: ellipsis;
@@ -20,7 +21,7 @@ $card_margin: 0.5rem;
     box-shadow: var(--origin-shadow);
     margin-bottom: 1rem;
     &--image {
-      margin: 0 $card_margin 0 $card_margin;
+      margin: 0 $card_image_margin 0 $card_image_margin;
     }
   }
   &__contents {

--- a/src/app/(header)/explore/_components/Tab/Tab.tsx
+++ b/src/app/(header)/explore/_components/Tab/Tab.tsx
@@ -17,9 +17,9 @@ export default function Tab({ handleSort, handleYear }: TabProps) {
 
   const yearMenu = [
     { name: '새해' },
-    {
-      name: '지난해',
-    },
+    // {
+    //   name: '지난해',
+    // },
   ];
   const sortMenu = [{ name: '최신순' }, { name: '인기순' }];
 

--- a/src/app/(header)/home/_components/NewPlan/NewPlan.tsx
+++ b/src/app/(header)/home/_components/NewPlan/NewPlan.tsx
@@ -11,6 +11,15 @@ export default function NewPlan() {
 
   return (
     <>
+      <div className={classNames('new-plan__servey')}>
+        <p>서비스를 잘 이용하고 계신가요?</p>
+        <a
+          href="https://forms.gle/VW5xBbAErQWqmdxv6"
+          className={classNames('color-origin-primary', 'new-plan__servey-a')}>
+          서비스 만족도 조사 하러가기
+        </a>
+      </div>
+
       <Link
         href={checkIsSeason() && canMakeNewPlan ? '/create' : {}}
         className={classNames('new-plan__wrapper')}

--- a/src/app/(header)/home/_components/NewPlan/index.scss
+++ b/src/app/(header)/home/_components/NewPlan/index.scss
@@ -11,4 +11,14 @@
     gap: 0.25rem;
     box-shadow: var(--origin-shadow);
   }
+  &__servey {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 0.5rem 0;
+    gap: 0.25rem;
+    &-a {
+      text-decoration-line: none;
+    }
+  }
 }


### PR DESCRIPTION
## 📌 이슈 번호

close #365 

## 🚀 구현 내용
- 태그가 없을 때 태그가 없습니다 문구 제거
- 둘러보기 지난해 탭 임시 제거
- 카드 아이콘 여백 늘리기
- 홈 설문조사 링크 추가
## 📘 참고 사항
![image](https://github.com/New-Barams/this-year-ajaja-fe/assets/67812466/5bbfb707-73f5-4284-8733-fd03cde9af19)
![image](https://github.com/New-Barams/this-year-ajaja-fe/assets/67812466/a9360ab9-8037-4898-b27d-5ee40c6b47cc)

![image](https://github.com/New-Barams/this-year-ajaja-fe/assets/67812466/f2f12f7b-a2db-4d45-9727-2a4c740aa0c9)
홈 설문조사 마진 수정했습니다.
<!--## ❓ 궁금한 내용-->
