### PR TITLE
[민우] - 계획 작성 시 리마인드 알림 도움말 버튼 추가 

### DIFF
--- a/src/components/CreatePlanContent/CreatePlanContent.tsx
+++ b/src/components/CreatePlanContent/CreatePlanContent.tsx
@@ -6,6 +6,7 @@ import { PlanContentType } from '@/types/Plan';
 import classNames from 'classnames';
 import { useEffect, useRef } from 'react';
 import { IconSwitchButton, InputTag, PlanInput, Tag } from '..';
+import HelpButton from '../HelpButton/HelpButton';
 import { useSessionStorage } from './../../hooks/useSessionStorage';
 import './index.scss';
 
@@ -173,6 +174,10 @@ export default function CreatePlanContent({
               ? '매주 월요일 18:00시 마다 응원 메세지 알림 활성화'
               : '응원 메세지 알림 비활성화'}
           </span>
+          <HelpButton
+            textPosition="top-left"
+            helpText={`매주 몇 명의 새로운 사람들이 내 계획에\n아좌좌를 눌러 응원했는지 알려드려요.`}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 📌 이슈 번호

close #366 

## 🚀 구현 내용
- [x] 계획 작성 시 리마인드 알림 도움말 버튼 추가 
<img width="278" alt="image" src="https://github.com/New-Barams/this-year-ajaja-fe/assets/31370590/89e43b85-66ee-4115-a1ca-0eb62014d4fa">


<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
