### PR TITLE
[민우] - 계획 작성 API 호출 시 생략된 field 추가

### DIFF
--- a/src/app/(header)/create/_components/StepButtonGroup/StepButtonGroup.tsx
+++ b/src/app/(header)/create/_components/StepButtonGroup/StepButtonGroup.tsx
@@ -81,6 +81,7 @@ export default function StepButtonGroup({
         remindDate: remindDate.Date,
         remindTime: changeRemindTimeToString(remindDate.Time),
         isPublic: planContent.isPublic,
+        canAjaja: planContent.canAjaja,
         iconNumber: planIcon,
         tags: planContent.tags,
 

--- a/src/types/apis/plan/PostNewPlan.ts
+++ b/src/types/apis/plan/PostNewPlan.ts
@@ -6,6 +6,7 @@ export interface PostNewPlanRequestBody {
   remindDate: number;
   remindTime: 'MORNING' | 'AFTERNOON' | 'EVENING';
   isPublic: boolean;
+  canAjaja: boolean;
   iconNumber: number;
   tags: string[];
   messages: RemindItem[];


### PR DESCRIPTION
## 📌 이슈 번호
close #380 

## 🚀 구현 내용
- [x] 계획 작성 API 호출 시 생략된 응원 메세지 알림 여부 속성 값 추가

<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
