### PR TITLE
[노철]- 수정, 마이페이지 

### DIFF
--- a/src/app/(header)/my/page.tsx
+++ b/src/app/(header)/my/page.tsx
@@ -196,7 +196,9 @@ export default function MyPage() {
           </Button>
         </div>
         <div className="my-page__etc font-size-base">
-          <button className="my-page__etc--logout" onClick={handleLogOut}>
+          <button
+            className="my-page__etc--logout color-origin-text-100"
+            onClick={handleLogOut}>
             로그아웃
           </button>
           <button

--- a/src/app/(header)/my/page.tsx
+++ b/src/app/(header)/my/page.tsx
@@ -122,7 +122,7 @@ export default function MyPage() {
     }
     return (
       <span className="color-origin-primary">
-        {receiveType === 'email' ? '이메일' : '카카오'}
+        {receiveType === 'email' ? '이메일' : '카카오톡'}
       </span>
     );
   };

--- a/src/app/(header)/plans/edit/[planId]/page.tsx
+++ b/src/app/(header)/plans/edit/[planId]/page.tsx
@@ -11,6 +11,7 @@ import {
   Tag,
 } from '@/components';
 import HelpButton from '@/components/HelpButton/HelpButton';
+import { ajajaToast } from '@/components/Toaster/customToast';
 import { planIcons } from '@/constants/planIcons';
 import { useEditPlanMutation } from '@/hooks/apis/useEditPlanMutation';
 import { useGetPlanQuery } from '@/hooks/apis/useGetPlanQuery';
@@ -49,7 +50,17 @@ export default function EditPage({ params }: { params: { planId: string } }) {
 
   const handleEditPlan = () => {
     // TODO:
-    editPlan({ planId: Number(planId), planData: planContent });
+    editPlan(
+      { planId: Number(planId), planData: planContent },
+      {
+        onError: () => {
+          ajajaToast.error('수정에 실패했습니다.');
+        },
+        onSuccess: () => {
+          router.replace(`/plans/${planId}`);
+        },
+      },
+    );
   };
 
   return (

--- a/src/components/ModalVerification/ModalVerification.tsx
+++ b/src/components/ModalVerification/ModalVerification.tsx
@@ -37,7 +37,7 @@ export default function ModalVerification({
   const [code, setCode] = useState<string>('');
   const [isValidEmail, setIsValidEmail] = useState<boolean>(true);
   const [isValidCode, setIsValidCode] = useState<boolean>(true);
-
+  //TODO: 에러 처리, onError에서 상태 변경하는 형식으로
   useEffect(() => {
     if (error && error.response) {
       const status = error.response.status;

--- a/src/components/ModalVerification/ModalVerification.tsx
+++ b/src/components/ModalVerification/ModalVerification.tsx
@@ -113,7 +113,7 @@ export default function ModalVerification({
               onChange={handleChangeEmail}
               placeholder="이메일을 입력해주세요"
             />
-            <div>
+            <div className="modal-verification-wrapper__items--button">
               <Button
                 size="md"
                 border={false}
@@ -149,7 +149,7 @@ export default function ModalVerification({
               value={code}
               onChange={handleChangeCode}
             />
-            <div>
+            <div className="modal-verification-wrapper__items--button">
               <Button
                 disabled={!isSuccess}
                 border={false}

--- a/src/components/ModalVerification/index.scss
+++ b/src/components/ModalVerification/index.scss
@@ -1,15 +1,19 @@
 .modal {
   &-verification-wrapper {
-    border-radius: var(--border-radius);
+    border-top-right-radius: var(--border-radius);
+    border-top-left-radius: var(--border-radius);
     border-top: 1px solid var(--origin-secondary);
     width: 100%;
-    max-height: 50%;
+    max-height: 70%;
     display: flex;
     flex-direction: column;
     align-items: center;
     position: relative;
-    padding: 2rem 1.5rem;
+    padding: 0 1.5rem;
 
+    &__text {
+      margin-top: 2rem;
+    }
     &__exit {
       position: absolute;
       top: 5px;
@@ -24,6 +28,9 @@
       flex-direction: column;
       align-items: center;
       width: 100%;
+      & > .button {
+        margin-bottom: 2rem;
+      }
     }
 
     &__items {

--- a/src/components/ModalVerification/index.scss
+++ b/src/components/ModalVerification/index.scss
@@ -31,6 +31,9 @@
       display: flex;
       flex-direction: column;
       gap: 2rem;
+      &--button {
+        flex-shrink: 0;
+      }
 
       &--item {
         display: flex;

--- a/src/components/PlanInput/PlanInput.tsx
+++ b/src/components/PlanInput/PlanInput.tsx
@@ -58,6 +58,7 @@ export default function PlanInput({
           'planInput',
           `planInput--${kind === 'content' ? 'content' : 'title'}`,
           `planInput--${editable ? 'editable' : 'disabled'}`,
+          'color-origin-text-100',
         )}
       />
       {editable && (


### PR DESCRIPTION
## 📌 이슈 번호

close #390 

## 🚀 구현 내용

- [x] 수신 방식, 카카오=> 카카오톡으로 변경
- [x] 이메일 인증 모달 버튼 밑에 마진 추가
- [x] 이메일 인증 버튼  줄어들지 않게  
- [x] 계획 수정 완료시 계획 페이지로 
- [x] 계획상세, 로그아웃 글자 색 변경

<!--## 📘 참고 사항-->

## ❓ 궁금한 내용
- 계획 상세에서 글자색 변경을 위해서 planInput component의 textarea 클래스에 직접 'color-origin-text-100'을 넣어줬습니다.  PlanInput 쓰는 곳을 다른 컴포넌트를 확인했는데 다 글자색이 검정색이라 괜찮을 것 같은데 , 혹시  문제가 될 수 있을까요?