### PR TITLE
[노철]- 이메일 인증 에러 핸들링 

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout({
 }) {
   const hasAuth = cookies().has('auth');
   return (
-    <html lang="en">
+    <html lang="ko">
       <head>
         <link
           rel="stylesheet"

--- a/src/components/ModalVerification/ModalVerification.tsx
+++ b/src/components/ModalVerification/ModalVerification.tsx
@@ -4,8 +4,9 @@ import { Button, Icon } from '@/components';
 import { usePostSendVerificationMutation } from '@/hooks/apis/usePostSendVerificationMutation';
 import { usePostVerifyMutation } from '@/hooks/apis/usePostVerifyMutation';
 import { checkEmailValidation } from '@/utils/checkEmailValidation';
+import { AxiosError } from 'axios';
 import classNames from 'classnames';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import './index.scss';
 
 interface ModalVerificationProps {
@@ -24,38 +25,42 @@ export default function ModalVerification({
     isPending,
     isSuccess,
     error,
-  } = usePostSendVerificationMutation();
+  } = usePostSendVerificationMutation({
+    throwOnError: (error) => {
+      const axiosError = error as AxiosError;
+      if (axiosError && axiosError.response) {
+        const status = axiosError.response.status;
+        if (status < 400 || status < 500) {
+          return false;
+        }
+      }
+      return true;
+    },
+  });
+
   const {
     mutateAsync: submitCertification,
     isPending: isVerifyPending,
     isError: isVerifyError,
     error: verifyError,
     isSuccess: isVerifySuccess,
-  } = usePostVerifyMutation();
+  } = usePostVerifyMutation({
+    throwOnError: (error) => {
+      const axiosError = error as AxiosError;
+      if (axiosError && axiosError.response) {
+        const status = axiosError.response.status;
+        if (status < 400 || status < 500) {
+          return false;
+        }
+      }
+      return true;
+    },
+  });
 
   const [email, setEmail] = useState<string>('');
   const [code, setCode] = useState<string>('');
   const [isValidEmail, setIsValidEmail] = useState<boolean>(true);
   const [isValidCode, setIsValidCode] = useState<boolean>(true);
-  //TODO: 에러 처리, onError에서 상태 변경하는 형식으로
-  useEffect(() => {
-    if (error && error.response) {
-      const status = error.response.status;
-      if (status <= 400 || status >= 500) {
-        throw error;
-      }
-    } else if (error) {
-      throw error;
-    }
-    if (verifyError && verifyError.response) {
-      const status = verifyError.response.status;
-      if (status <= 400 || status >= 500) {
-        throw verifyError;
-      }
-    } else if (verifyError) {
-      throw verifyError;
-    }
-  }, [error, verifyError]);
 
   const handleChangeEmail = (event: React.ChangeEvent<HTMLInputElement>) => {
     setEmail(event.target.value);

--- a/src/components/ModalVerification/ModalVerification.tsx
+++ b/src/components/ModalVerification/ModalVerification.tsx
@@ -30,7 +30,7 @@ export default function ModalVerification({
       const axiosError = error as AxiosError;
       if (axiosError && axiosError.response) {
         const status = axiosError.response.status;
-        if (status < 400 || status < 500) {
+        if (status > 400 && status < 500) {
           return false;
         }
       }
@@ -39,7 +39,7 @@ export default function ModalVerification({
   });
 
   const {
-    mutateAsync: submitCertification,
+    mutate: submitCertification,
     isPending: isVerifyPending,
     isError: isVerifyError,
     error: verifyError,
@@ -49,7 +49,7 @@ export default function ModalVerification({
       const axiosError = error as AxiosError;
       if (axiosError && axiosError.response) {
         const status = axiosError.response.status;
-        if (status < 400 || status < 500) {
+        if (status > 400 && status < 500) {
           return false;
         }
       }
@@ -79,11 +79,14 @@ export default function ModalVerification({
     const inputValue = event.target.value.replace(/[^0-9]/g, '');
     setCode(inputValue);
   };
-  const handleSubmitCode = async () => {
+  const handleSubmitCode = () => {
     if (code.length == 6) {
       setIsValidCode(true);
-      await submitCertification(code);
-      setVerifiedEmail && setVerifiedEmail();
+      submitCertification(code, {
+        onSuccess: () => {
+          setVerifiedEmail && setVerifiedEmail();
+        },
+      });
     } else {
       setIsValidCode(false);
     }

--- a/src/hooks/apis/usePostSendVerificationMutation.ts
+++ b/src/hooks/apis/usePostSendVerificationMutation.ts
@@ -1,14 +1,18 @@
 import { postSendVerification } from '@/apis/client/postSendVerification';
-import { useMutation } from '@tanstack/react-query';
+import { UseMutationOptions, useMutation } from '@tanstack/react-query';
 import { AxiosError, AxiosResponse } from 'axios';
 
-export const usePostSendVerificationMutation = () => {
+export const usePostSendVerificationMutation = ({
+  throwOnError,
+}: UseMutationOptions) => {
   const { mutate, isError, isSuccess, error, isPending } = useMutation<
     AxiosResponse,
     AxiosError<ErrorResponseData>,
     string
   >({
     mutationFn: (email: string) => postSendVerification(email),
+
+    throwOnError,
   });
   return {
     mutate,

--- a/src/hooks/apis/usePostSendVerificationMutation.ts
+++ b/src/hooks/apis/usePostSendVerificationMutation.ts
@@ -11,7 +11,6 @@ export const usePostSendVerificationMutation = ({
     string
   >({
     mutationFn: (email: string) => postSendVerification(email),
-
     throwOnError,
   });
   return {

--- a/src/hooks/apis/usePostVerifyMutation.ts
+++ b/src/hooks/apis/usePostVerifyMutation.ts
@@ -3,7 +3,7 @@ import { UseMutationOptions, useMutation } from '@tanstack/react-query';
 import { AxiosError, AxiosResponse } from 'axios';
 
 export const usePostVerifyMutation = ({ throwOnError }: UseMutationOptions) => {
-  const { isError, error, isPending, isSuccess, mutateAsync } = useMutation<
+  const { isError, error, isPending, isSuccess, mutate } = useMutation<
     AxiosResponse,
     AxiosError<ErrorResponseData>,
     string
@@ -11,7 +11,7 @@ export const usePostVerifyMutation = ({ throwOnError }: UseMutationOptions) => {
     mutationFn: postVerify,
     throwOnError,
   });
-  return { mutateAsync, isError, error, isPending, isSuccess };
+  return { mutate, isError, error, isPending, isSuccess };
 };
 
 interface ErrorResponseData {

--- a/src/hooks/apis/usePostVerifyMutation.ts
+++ b/src/hooks/apis/usePostVerifyMutation.ts
@@ -1,14 +1,15 @@
 import { postVerify } from '@/apis/client/postVerify';
-import { useMutation } from '@tanstack/react-query';
+import { UseMutationOptions, useMutation } from '@tanstack/react-query';
 import { AxiosError, AxiosResponse } from 'axios';
 
-export const usePostVerifyMutation = () => {
+export const usePostVerifyMutation = ({ throwOnError }: UseMutationOptions) => {
   const { isError, error, isPending, isSuccess, mutateAsync } = useMutation<
     AxiosResponse,
     AxiosError<ErrorResponseData>,
     string
   >({
     mutationFn: postVerify,
+    throwOnError,
   });
   return { mutateAsync, isError, error, isPending, isSuccess };
 };


### PR DESCRIPTION
## 📌 이슈 번호

close #402

## 🚀 구현 내용
- 이메일 인증 관련 에러를 useEffect로 하고 있었는데 적절하지 않아서 react-query의 throwOnError로 변경
- html lang ko 변경

<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
