### PR TITLE
[민우] - 공지사항 페이지 구현 

### DIFF
--- a/src/app/(headerless)/notice/error.tsx
+++ b/src/app/(headerless)/notice/error.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { BasicError } from '@/components';
+
+export default function ErrorPage({
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  return <BasicError reset={reset} />;
+}

--- a/src/app/(headerless)/notice/index.scss
+++ b/src/app/(headerless)/notice/index.scss
@@ -1,6 +1,24 @@
 .notice-page {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 2rem;
+  &__wrapper {
+    display: flex;
+    flex-direction: column;
+    padding: 0.5rem;
+  }
+
+  &__title{
+    align-self: center;
+    margin-top: 2.5rem;
+  }
+
+  &__notice-title{
+    margin-top: 2rem;
+  }
+
+  &__notice-date{
+    margin-top: 0.5rem;
+  }
+
+  &__notice-content{
+    margin-top: 1.5rem;
+  }
 }

--- a/src/app/(headerless)/notice/index.scss
+++ b/src/app/(headerless)/notice/index.scss
@@ -1,0 +1,6 @@
+.notice-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem;
+}

--- a/src/app/(headerless)/notice/index.scss
+++ b/src/app/(headerless)/notice/index.scss
@@ -15,10 +15,11 @@
   }
 
   &__notice-date{
-    margin-top: 0.5rem;
+    margin-top: 0.25rem;
   }
 
   &__notice-content{
-    margin-top: 1.5rem;
+    margin-top: 1rem;
+    line-height: 1.5rem; 
   }
 }

--- a/src/app/(headerless)/notice/page.tsx
+++ b/src/app/(headerless)/notice/page.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import './index.scss';
+
+export default function NoticePage() {
+  return (
+    <div>
+      <h1 className="notice-page font-size-xl">공지사항</h1>
+    </div>
+  );
+}

--- a/src/app/(headerless)/notice/page.tsx
+++ b/src/app/(headerless)/notice/page.tsx
@@ -16,7 +16,7 @@ export default function NoticePage() {
 
       <p className="notice-page__notice-content">
         개인정보 처리방침 변경이 변경되어 전화번호를 무조건 수집해야합니다.
-        개인정보 처리방침 변경이 변경되어 전화번 호 를 무조건 수집해야합니다.
+        개인정보 처리방침 변경이 변경되어 전화번호를 무조건 수집해야합니다.
       </p>
     </div>
   );

--- a/src/app/(headerless)/notice/page.tsx
+++ b/src/app/(headerless)/notice/page.tsx
@@ -3,8 +3,21 @@ import './index.scss';
 
 export default function NoticePage() {
   return (
-    <div>
-      <h1 className="notice-page font-size-xl">공지사항</h1>
+    <div className="notice-page__wrapper">
+      <h1 className="notice-page__title font-size-xl">공지사항</h1>
+
+      <p className="notice-page__notice-title font-size-lg">
+        개인정보 처리방침 변경 안내
+      </p>
+
+      <p className="notice-page__notice-date font-size-base color-origin-secondary">
+        2024.01.23
+      </p>
+
+      <p className="notice-page__notice-content">
+        개인정보 처리방침 변경이 변경되어 전화번호를 무조건 수집해야합니다.
+        개인정보 처리방침 변경이 변경되어 전화번 호 를 무조건 수집해야합니다.
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## 📌 이슈 번호

close #416 

## 🚀 구현 내용
공지사항 페이지 dummy data로 임시로 구현해두었습니다. 
<img width="333" alt="image" src="https://github.com/New-Barams/this-year-ajaja-fe/assets/31370590/1b0cd306-0d28-4fdc-9e91-dfc48eb92116">

<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
