### PR TITLE
[혜수] - 둘러보기 카드에서 올해 작성한 계획은 년도 제거하고 날짜 넣기

### DIFF
--- a/src/app/(header)/explore/_components/Card/Card.tsx
+++ b/src/app/(header)/explore/_components/Card/Card.tsx
@@ -1,6 +1,7 @@
 import { AjajaButton, Tag } from '@/components';
 import { planIcons } from '@/constants/planIcons';
 import { CardPlans } from '@/types/apis/plan/GetAllPlans';
+import { checkThisYear } from '@/utils/checkThisYear';
 import classNames from 'classnames';
 import Image from 'next/image';
 import './index.scss';
@@ -32,7 +33,16 @@ export default function Card({ plan }: CardProps) {
           {plan.title}
         </p>
         <p className={classNames('card__contents--nickname', 'font-size-xs')}>
-          {plan.nickname}님의 계획 • {plan.createdAt.slice(0, 4)}년 작성
+          {parseInt(plan.createdAt.slice(0, 4)) === checkThisYear() ? (
+            <div>
+              {plan.nickname}님의 계획 • {plan.createdAt.slice(5, 7)}월{' '}
+              {plan.createdAt.slice(8, 10)}일 작성
+            </div>
+          ) : (
+            <div>
+              {plan.nickname}님의 계획 • {plan.createdAt.slice(0, 4)}년 작성
+            </div>
+          )}
         </p>
         <AjajaButton
           planId={plan.id}

--- a/src/app/(header)/explore/_components/Card/index.scss
+++ b/src/app/(header)/explore/_components/Card/index.scss
@@ -45,7 +45,7 @@ $card_image_margin: 1rem;
     }
     &--tags {
       @include ellipsis(2);
-      height: 2.5rem;
+      height: 3rem;
     }
   }
 }


### PR DESCRIPTION
## 📌 이슈 번호

close #421 

## 🚀 구현 내용
- 둘러보기 카드에서 올해 작성한 계획은 년도 제거하고 날짜 넣기
- 태그 2줄일 때 아래 공간 추가
## 📘 참고 사항
![image](https://github.com/New-Barams/this-year-ajaja-fe/assets/67812466/36b8ac81-72a9-4949-891c-865d10214e5a)

<!--## ❓ 궁금한 내용-->
