### PR TITLE
[민우] - 리마인드 예시 보내보기 API 연동 작업

### DIFF
--- a/src/apis/client/postRemindTest.ts
+++ b/src/apis/client/postRemindTest.ts
@@ -1,0 +1,7 @@
+import { DOMAIN } from '@/constants/api';
+import { axiosInstanceClient } from '../axiosInstanceClient';
+
+export const postRemindTest = async () => {
+  const { data } = await axiosInstanceClient.post(DOMAIN.POST_REMINDS_TEST);
+  return data;
+};

--- a/src/apis/client/postRemindTest.ts
+++ b/src/apis/client/postRemindTest.ts
@@ -1,7 +1,14 @@
 import { DOMAIN } from '@/constants/api';
 import { axiosInstanceClient } from '../axiosInstanceClient';
 
+interface PostRemindTestResponse {
+  success: boolean;
+  data: 'EMAIL' | 'KAKAO' | 'BOTH';
+}
+
 export const postRemindTest = async () => {
-  const { data } = await axiosInstanceClient.post(DOMAIN.POST_REMINDS_TEST);
+  const { data } = await axiosInstanceClient.post<PostRemindTestResponse>(
+    DOMAIN.POST_REMINDS_TEST,
+  );
   return data;
 };

--- a/src/components/ModalSendRemindExample/ModalSendRemindExample.tsx
+++ b/src/components/ModalSendRemindExample/ModalSendRemindExample.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { usePostRemindTest } from '@/hooks/apis/usePostRemindTest';
 import classNames from 'classnames';
 import Image from 'next/image';
 import React from 'react';
@@ -15,13 +16,14 @@ interface ModalSendRemindExampleProps {
 export default function ModalSendRemindExample({
   closeModal,
 }: ModalSendRemindExampleProps) {
-  const sendRemindExample = () => {
-    console.log('예시 리마인드 전송 후 완료 시 toast 띄우기 ! ');
-  };
+  const { mutate: sendRemindTest } = usePostRemindTest();
+
+  // const sendRemindExample = () => {
+  //   console.log('예시 리마인드 전송 후 완료 시 toast 띄우기 ! ');
+  // };
 
   const onClickSendRemindExample = () => {
-    sendRemindExample();
-    closeModal();
+    sendRemindTest();
   };
 
   return (

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -38,6 +38,7 @@ export const DOMAIN = {
 
   GET_REMINDS: (planId: number) => `/reminds/${planId}`,
   PUT_REMINDS: (planId: number) => `/plans/${planId}/reminds`,
+  POST_REMINDS_TEST: `/reminds/test`,
 };
 
 // 실제 API -> swagger 순서입니다.

--- a/src/hooks/apis/usePostRemindTest.ts
+++ b/src/hooks/apis/usePostRemindTest.ts
@@ -1,0 +1,25 @@
+import { postRemindTest } from '@/apis/client/postRemindTest';
+import { ajajaToast } from '@/components/Toaster/customToast';
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+export const usePostRemindTest = () => {
+  return useMutation({
+    mutationFn: postRemindTest,
+    onSuccess: (data) => {
+      console.log(data);
+      ajajaToast.success('리마인드 테스트 성공');
+    },
+    onError: (error) => {
+      const axiosError = error as AxiosError;
+      if (axiosError && axiosError.response) {
+        const statusCode = axiosError.response.status;
+        if (statusCode === 429) {
+          // 3회 초과 시도 시
+          ajajaToast.error('3번을 초과했습니다.');
+        }
+      }
+      ajajaToast.error('리마인드 테스트 실패');
+    },
+  });
+};

--- a/src/hooks/apis/usePostRemindTest.ts
+++ b/src/hooks/apis/usePostRemindTest.ts
@@ -7,8 +7,12 @@ export const usePostRemindTest = () => {
   return useMutation({
     mutationFn: postRemindTest,
     onSuccess: (data) => {
-      console.log(data);
-      ajajaToast.success('리마인드 테스트 성공');
+      const sendMethod = data.data;
+      if (sendMethod === 'EMAIL') {
+        ajajaToast.success('이메일로 발송되었습니다.');
+      } else {
+        ajajaToast.success('카카오톡으로 발송되었습니다.');
+      }
     },
     onError: (error) => {
       const axiosError = error as AxiosError;

--- a/src/hooks/apis/usePostRemindTest.ts
+++ b/src/hooks/apis/usePostRemindTest.ts
@@ -21,9 +21,10 @@ export const usePostRemindTest = () => {
         if (statusCode === 429) {
           // 3회 초과 시도 시
           ajajaToast.error('3번을 초과했습니다.');
+        } else {
+          ajajaToast.error('리마인드 테스트 실패');
         }
       }
-      ajajaToast.error('리마인드 테스트 실패');
     },
   });
 };


### PR DESCRIPTION
## 📌 이슈 번호

close #423

## 🚀 구현 내용
- [x] 리마인드 테스트 API 경로 추가 및 Axios post 함수 정의 66a1aeb88c4103318b64f852fe4d30a74a5db18d
- [x] 리마인드 테스트 API useMutation 훅 정의 f370fed2209ea5d218948fdc010093f8bc555300
- [x] 리마인드 테스트 API 모달에 연결 8cbaa987846a0509e905462fb964868cb4025d1f
- [x] 리마인드 테스트 API response 타입 정의 및 응답값에 따른 분기처리 4af660797fa5bdbe821a020e1a3670970b379f16

<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
