### PR TITLE
[노철] - 마이페이지 공지사항 추가

### DIFF
--- a/src/app/(header)/my/index.scss
+++ b/src/app/(header)/my/index.scss
@@ -64,6 +64,10 @@
     flex-direction: column;
     gap: 1rem;
     align-items: flex-start;
+
+    &--notice {
+      text-decoration: none;
+    }
   }
 }
 

--- a/src/app/(header)/my/page.tsx
+++ b/src/app/(header)/my/page.tsx
@@ -18,6 +18,7 @@ import { useScroll } from '@/hooks/useScroll';
 import { ReceiveType } from '@/types/apis/users/GetUserInformation';
 import { useQueryClient } from '@tanstack/react-query';
 import { deleteCookie } from 'cookies-next';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import ModalRemindWay from './_components/ModalRemindWay/ModalRemindWay';
@@ -197,6 +198,11 @@ export default function MyPage() {
           </Button>
         </div>
         <div className="my-page__etc font-size-base">
+          <Link
+            className="my-page__etc--notice color-origin-text-100"
+            href={'/notice'}>
+            공지사항
+          </Link>
           <button
             className="my-page__etc--logout color-origin-text-100"
             onClick={handleLogOut}>

--- a/src/components/ReadOnlyPlan/ReadOnlyPlan.tsx
+++ b/src/components/ReadOnlyPlan/ReadOnlyPlan.tsx
@@ -115,9 +115,6 @@ export default function ReadOnlyPlan({
               textPosition={canAjaja ? 'top-left' : 'top'}
             />
           </div>
-          <span className="font-size-xs color-origin-primary">
-            현재 카카오톡 알림은 2월 부터 받으실 수 있습니다.
-          </span>
         </div>
       )}
     </div>


### PR DESCRIPTION
## 📌 이슈 번호

close #430 

## 🚀 구현 내용
- 마이페이지 공지 사항  링크 추가
- 계획 상세  카카오 주의 사항 문구 제거 
<img width="548" alt="image" src="https://github.com/New-Barams/this-year-ajaja-fe/assets/61609327/f7af5f16-f653-4b06-a584-692994189f71">
<img width="546" alt="스크린샷 2024-01-24 224214" src="https://github.com/New-Barams/this-year-ajaja-fe/assets/61609327/38ee53c2-c99d-4967-ad93-c71ceb580031">

<!--## 📘 참고 사항-->

<!--## ❓ 궁금한 내용-->
